### PR TITLE
add command line parameter --depthLimit

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -16,13 +16,15 @@ Using some concurrency, fairly deep exploration is quickly possible
 This is a command line program. 
 
 ```
-usage: search.py [-h] [--epd EPD] [--concurrency CONCURRENCY] [--evalDecay EVALDECAY]
+usage: search.py [-h] [--epd EPD] [--depthLimit DEPTHLIMIT] [--concurrency CONCURRENCY] [--evalDecay EVALDECAY]
 
 Explore and extend the Chess Cloud Database (https://chessdb.cn/queryc_en/). Builds a search tree for a given position (FEN/EPD)
 
 options:
   -h, --help            show this help message and exit
   --epd EPD             epd to explore (default: rnbqkbnr/pppppppp/8/8/6P1/8/PPPPPP1P/RNBQKBNR b KQkq g3)
+  --depthLimit DEPTHLIMIT
+                        finish the exploration at the specified depth (default: None)
   --concurrency CONCURRENCY
                         concurrency of requests. This is the maximum number of requests made to chessdb at the same time. (default: 16)
   --evalDecay EVALDECAY

--- a/search.py
+++ b/search.py
@@ -353,6 +353,12 @@ if __name__ == "__main__":
         default="rnbqkbnr/pppppppp/8/8/6P1/8/PPPPPP1P/RNBQKBNR b KQkq g3",
     )
     argParser.add_argument(
+        "--depthLimit",
+        help="finish the exploration at the specified depth",
+        type=int,
+        default=None,
+    )
+    argParser.add_argument(
         "--concurrency",
         help="concurrency of requests. This is the maximum number of requests made to chessdb at the same time.",
         type=int,
@@ -366,6 +372,7 @@ if __name__ == "__main__":
     )
     args = argParser.parse_args()
     epd = args.epd
+    depthLimit = args.depthLimit
 
     # limit stack size of created threads, many are created
     stackSize = 4096 * 64
@@ -383,7 +390,7 @@ if __name__ == "__main__":
     # set initial board
     board = chess.Board(epd)
     depth = 1
-    while True:
+    while depthLimit is None or depth <= depthLimit:
         bestscore, pv = chessdb.search(board, depth)
         pvline = ""
         for m in pv:


### PR DESCRIPTION
Adding a command line parameter to allow exploration to stop when a certain depth is reached.

Default behaviour is unchanged.

This will allow future work, where I plan to create a method cdbexplore() to invoke a finite search from within other scripts.

@vondele: Would you be happy for me to rename search.py into cdbexplore.py within the above indicated possible next PR?