### PR TITLE
stop exploration once proven win is found

### DIFF
--- a/cdbsearch.py
+++ b/cdbsearch.py
@@ -362,7 +362,10 @@ def cdbsearch(epd, depthLimit, concurrency, evalDecay):
         move = chess.Move.from_uci(m)
         board.push(move)
     depth = 1
-    while depthLimit is None or depth <= depthLimit:
+    bestscore = 0
+    # we stop the exploration once the prescribed depth is reached, or once bestscore indicates a proven win
+    # note that cdb stores mates and TB wins as 30000-ply, and cursed wins as 20000-ply
+    while (depthLimit is None or depth <= depthLimit) and abs(bestscore) <= 10000:
         bestscore, pv = chessdb.search(board, depth)
         runtime = time.perf_counter() - chessdb.count_starttime
         print("Search at depth ", depth)


### PR DESCRIPTION
At the moment calls such as `python cdbsearch.py --san "1. f3 e5 2. g4"` and `python cdbsearch.py --epd "3K4/pp3B2/qrk5/bp2B3/1p1P4/1P6/5P2/8 w - -"` lead to an infinite loop without further meaningful exploration.

The change means we always stop exploration once |bestscore| > 10000. Note that cdb stores checkmates and tbwins as 30000, with cursed wins as 20000.
