### PR TITLE
fix divide by zero error

### DIFF
--- a/cdbsearch.py
+++ b/cdbsearch.py
@@ -376,13 +376,14 @@ def cdbsearch(epd, depthLimit, concurrency, evalDecay):
     while depthLimit is None or depth <= depthLimit:
         bestscore, pv = chessdb.search(board, depth)
         runtime = time.perf_counter() - chessdb.count_starttime
+        queryall = chessdb.count_queryall.get()
         print("Search at depth ", depth)
         print("  score     : ", bestscore)
         print("  PV        : ", " ".join(pv))
-        print("  queryall  : ", chessdb.count_queryall.get())
-        print(f"  bf        :  { chessdb.count_queryall.get()**(1/depth) :.2f}")
+        print("  queryall  : ", queryall)
+        print(f"  bf        :  { queryall**(1/depth) :.2f}")
         print(
-            f"  inflight  : { chessdb.count_sumInflightRequests.get() / chessdb.count_queryall.get() : .2f}"
+            f"  inflight  : { chessdb.count_sumInflightRequests.get() / max(queryall, 1) : .2f}"
         )
         print("  chessdbq  : ", chessdb.count_uncached.get())
         print("  enqueued  : ", chessdb.count_enqueued.get())
@@ -390,7 +391,7 @@ def cdbsearch(epd, depthLimit, concurrency, evalDecay):
         print("  total time: ", int(1000 * runtime))
         print(
             "  req. time : ",
-            int(1000 * runtime / chessdb.count_uncached.get()),
+            int(1000 * runtime / max(chessdb.count_uncached.get(), 1)),
         )
 
         pvline = " ".join(

--- a/cdbsearch.py
+++ b/cdbsearch.py
@@ -402,6 +402,8 @@ def cdbsearch(epd, depthLimit, concurrency, evalDecay):
 
         print("", flush=True)
         depth += 1
+        if queryall == 0:  # this can only happen if initial board is checkmate or draw
+            break
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
With current main the call `python cdbsearch.py --san "1. g4 Nc6 2. Nf3 Nb8 3. Ng1 Nc6 4. Nf3 Nb8"` leads to a division by zero error.

This PR contains the minimal fix.