### PR TITLE
cdbbulksearch

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,19 +1,17 @@
 # Explore and extend the Chess Cloud Database 
 
-Explores and searches the largest online database (db) of chess positions and openings:
-
-[chessdb](https://chessdb.cn/queryc_en/)
+Explores and searches [chessdb.cn](https://chessdb.cn/queryc_en/), the largest online database (db) of chess positions and openings.
 
 ## Purpose
 
 Build a search tree from a particular position, using a mini-max like algorithm,
 finding the best line, extending the db as needed.
 
-Using some concurrency, fairly deep exploration is quickly possible
+Using some concurrency, fairly deep exploration is quickly possible.
 
-## Usage
+## `cdbsearch`
 
-This is a command line program. 
+This is a command line program to explore a single position.
 
 ```
 usage: cdbsearch.py [-h] [--epd EPD | --san SAN] [--depthLimit DEPTHLIMIT] [--concurrency CONCURRENCY] [--evalDecay EVALDECAY]
@@ -63,6 +61,35 @@ date       : ... you guessed it
 total time : Time spent in milliseconds since the start of the search.
 req. time  : Average time needed to get a cdb list of moves for a position (including those that required enqueuing).
 URL        : Link displaying the found PV in chessdb.
+```
+
+## `cdbbulksearch`
+
+This is a command line program to sequentially explore several positions.
+```
+usage: cdbbulksearch.py [-h] [--depthLimit DEPTHLIMIT] [--concurrency CONCURRENCY] [--evalDecay EVALDECAY] [--forever] filename
+
+Sequentially call cdbsearch for EPDs or book exits stored in a file.
+
+positional arguments:
+  filename              PGN file if suffix is .pgn, o/w a text file with EPDs.
+
+options:
+  -h, --help            show this help message and exit
+  --depthLimit DEPTHLIMIT
+                        Argument passed to cdbsearch. (default: 22)
+  --concurrency CONCURRENCY
+                        Argument passed to cdbsearch. (default: 16)
+  --evalDecay EVALDECAY
+                        Argument passed to cdbsearch. (default: 2)
+  --forever             Pass positions from filename to cdbsearch in an infinite loop. (default: False)
+```
+
+Example:
+```shell
+echo '[Event "*"]\n\n1. g4 *\n\n1. g4 d5 *\n' > book.pgn
+git clone https://github.com/vondele/cdbexplore
+python3 cdbexplore/cdbbulksearch.py book.pgn --forever >& cdbsearch_book.log &
 ```
 
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)

--- a/cdbbulksearch.py
+++ b/cdbbulksearch.py
@@ -1,0 +1,91 @@
+import argparse, sys
+import chess, chess.pgn
+import cdbsearch
+
+
+argParser = argparse.ArgumentParser(
+    description="Sequentially call cdbsearch for EPDs or book exits stored in a file.",
+    formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+)
+argParser.add_argument(
+    "filename", help="PGN file if suffix is .pgn, o/w a text file with EPDs."
+)
+argParser.add_argument(
+    "--depthLimit",
+    help="Argument passed to cdbsearch.",
+    type=int,
+    default=22,
+)
+argParser.add_argument(
+    "--concurrency",
+    help="Argument passed to cdbsearch.",
+    type=int,
+    default=16,
+)
+argParser.add_argument(
+    "--evalDecay",
+    help="Argument passed to cdbsearch.",
+    type=int,
+    default=2,
+)
+argParser.add_argument(
+    "--forever",
+    action="store_true",
+    help="Pass positions from filename to cdbsearch in an infinite loop.",
+)
+args = argParser.parse_args()
+
+if sys.maxsize <= 2**32:
+    # on 32-bit systems we limit thread stack size, as many are created
+    stackSize = 4096 * 64
+    threading.stack_size(stackSize)
+
+isPGN = args.filename.endswith(".pgn")
+while True:  # if args.forever is true, run indefinitely; o/w stop after one run
+    # re-reading the data in each loop allows updates to it in the background
+    metalist = []
+    if isPGN:
+        pgn = open(args.filename)
+        while game := chess.pgn.read_game(pgn):
+            metalist.append(game)
+        print(f"Read {len(metalist)} (opening) lines from file {args.filename}.")
+    else:
+        with open(args.filename) as f:
+            for line in f:
+                line = line.strip()
+                if line:
+                    if line.startswith("#"):  # ignore comments
+                        continue
+                    epd, _, moves = line.partition("moves")
+                    epd = " ".join(epd.split()[:4])  # cdb ignores move counters anyway
+                    epdMoves = " moves"
+                    for m in moves.split():
+                        if (
+                            len(m) != 4
+                            or not {m[0], m[2]}.issubset(set("abcdefgh"))
+                            or not {m[1], m[3]}.issubset(set("12345678"))
+                        ):
+                            break
+                        epdMoves += f" {m}"
+                    if epdMoves != " moves":
+                        epd += epdMoves
+                    metalist.append(epd)
+        print(f"Read {len(metalist)} EPDs from file {args.filename}.")
+    for item in metalist:
+        if isPGN:
+            epd = item.board().epd()
+            if len(list(item.mainline_moves())):
+                epd += " moves"
+            for move in item.mainline_moves():
+                epd += f" {move}"
+        else:
+            epd = item
+        cdbsearch.cdbsearch(
+            epd=epd,
+            depthLimit=args.depthLimit,
+            concurrency=args.concurrency,
+            evalDecay=args.evalDecay,
+        )
+    print(f"Done processing {args.filename}.")
+    if not args.forever:
+        break


### PR DESCRIPTION
Provide a script to sequentially explore positions from a file.

This allows users to widen and deepen the cdb tree starting from certain positions or book exits they are interested in.

The script can be run indefinitely, with edits to the file storing the positions affecting future searches.