### PR TITLE
allow uci moves with promotions

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -90,7 +90,7 @@ options:
 Example:
 ```shell
 echo '[Event "*"]\n\n1. g4 *\n\n1. g4 d5 *\n' > book.pgn
-git clone https://github.com/vondele/cdbexplore
+git clone https://github.com/vondele/cdbexplore && pip install -r cdbexplore/requirements.txt
 python3 cdbexplore/cdbbulksearch.py book.pgn --forever >& cdbsearch_book.log &
 ```
 

--- a/cdbbulksearch.py
+++ b/cdbbulksearch.py
@@ -68,9 +68,11 @@ while True:  # if args.forever is true, run indefinitely; o/w stop after one run
                     epdMoves = " moves"
                     for m in moves.split():
                         if (
-                            len(m) != 4
+                            len(m) < 4
+                            or len(m) > 5
                             or not {m[0], m[2]}.issubset(set("abcdefgh"))
                             or not {m[1], m[3]}.issubset(set("12345678"))
+                            or (len(m) == 5 and not m[4] in "qrbn")
                         ):
                             break
                         epdMoves += f" {m}"
@@ -79,7 +81,9 @@ while True:  # if args.forever is true, run indefinitely; o/w stop after one run
                     metalist.append(epd)
         print(f"Read {len(metalist)} EPDs from file {args.filename}.")
 
-    with concurrent.futures.ProcessPoolExecutor(max_workers=args.bulkConcurrency) as executor:
+    with concurrent.futures.ProcessPoolExecutor(
+        max_workers=args.bulkConcurrency
+    ) as executor:
         for item in metalist:
             if isPGN:
                 epd = item.board().epd()


### PR DESCRIPTION
Due to an oversight in https://github.com/vondele/cdbexplore/pull/10 moves with promotions are currently not recognized.

Besides fixing the bug we add `pip` instructions to the example in the readme and use black to reformat.

PS: I noticed that running the script with --bulkConcurrency larger than 1 means the processes spawned by the script can no longer be killed with Ctrl-C from the command line. Some users may not like that? Is there any way to prevent this?