### PR TITLE
catch errors, adapt output

### DIFF
--- a/cdbbulksearch.py
+++ b/cdbbulksearch.py
@@ -15,7 +15,7 @@ def wrapcdbsearch(epd, depthLimit, concurrency, evalDecay):
             epd=epd, depthLimit=depthLimit, concurrency=concurrency, evalDecay=evalDecay
         )
     except Exception as ex:
-        print(f" error: while searching {epd} caught exception {ex}")
+        print(f' error: while searching {epd} caught exception "{ex}"')
     sys.stdout = old_stdout
     return mystdout.getvalue()
 
@@ -160,7 +160,7 @@ if __name__ == "__main__":
                 try:
                     print(f.result(), flush=True)
                 except Exception as ex:
-                    print(f" error: caught exception {ex}")
+                    print(f' error: caught exception "{ex}"')
 
         print(f"Done processing {args.filename}.")
         if not args.forever:


### PR DESCRIPTION
This PR allows to catch errors that arise from one of the spawned processes. The script will now continue as normal with the remaining positions to explore.

Adapt the output slightly to show users (a) what EPD is causing the current hold up and (b) which EPD led to a termination of its exploration process.

Fixes https://github.com/vondele/cdbexplore/issues/19