### PR TITLE
by default treat cursed wins as draws

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -28,6 +28,7 @@ options:
                         Concurrency of requests. This is the maximum number of requests made to chessdb at the same time. (default: 16)
   --evalDecay EVALDECAY
                         Depth decrease per cp eval-to-best. A small number will use a very narrow search, 0 will essentially just follow PV lines. A wide search will likely enqueue many positions. (default: 2)
+  --cursedWins          Treat cursed wins as wins. (default: False)
 ``` 
 
 Sample output:
@@ -83,6 +84,7 @@ options:
                         Argument passed to cdbsearch. (default: 16)
   --evalDecay EVALDECAY
                         Argument passed to cdbsearch. (default: 2)
+  --cursedWins          Argument passed to cdbsearch. (default: False)
   --bulkConcurrency BULKCONCURRENCY
                         Number of concurrent processes running cdbsearch. (default: 4)
   --forever             Pass positions from filename to cdbsearch in an infinite loop. (default: False)

--- a/cdbbulksearch.py
+++ b/cdbbulksearch.py
@@ -7,12 +7,16 @@ import signal
 from multiprocessing import freeze_support, active_children
 
 
-def wrapcdbsearch(epd, depthLimit, concurrency, evalDecay):
+def wrapcdbsearch(epd, depthLimit, concurrency, evalDecay, cursedWins=False):
     old_stdout = sys.stdout
     sys.stdout = mystdout = StringIO()
     try:
         cdbsearch.cdbsearch(
-            epd=epd, depthLimit=depthLimit, concurrency=concurrency, evalDecay=evalDecay
+            epd=epd,
+            depthLimit=depthLimit,
+            concurrency=concurrency,
+            evalDecay=evalDecay,
+            cursedWins=cursedWins,
         )
     except Exception as ex:
         print(f' error: while searching {epd} caught exception "{ex}"')
@@ -46,6 +50,11 @@ if __name__ == "__main__":
         help="Argument passed to cdbsearch.",
         type=int,
         default=2,
+    )
+    argParser.add_argument(
+        "--cursedWins",
+        action="store_true",
+        help="Argument passed to cdbsearch.",
     )
     argParser.add_argument(
         "--bulkConcurrency",
@@ -145,6 +154,7 @@ if __name__ == "__main__":
                             depthLimit=args.depthLimit,
                             concurrency=args.concurrency,
                             evalDecay=args.evalDecay,
+                            cursedWins=args.cursedWins,
                         ),
                     )
                 )


### PR DESCRIPTION
Currently cdbsearch takes over cdb's interpretation of cursed wins being wins. This PR changes that behaviour to treating them as draws, as per FIDE rules. Users who want to treat cursed wins as wins can do so with the `--cursedWins` command line option.

Old behaviour:
```shell
> python cdbsearch.py --epd "8/2B5/1k6/1Q6/8/3K4/4N1R1/qn6 b - - 0 1" --depthLimit 2
Searched epd :  8/2B5/1k6/1Q6/8/3K4/4N1R1/qn6 b - - 0 1
evalDecay:  2
Concurrency  :  16
Starting date:  2023-05-16T17:31:06.998073
Search at depth  1
  score     :  18967
  PV        :  b6b5 g2g5
  queryall  :  2
  bf        :  2.00
  inflight  :  0.00
  chessdbq  :  2
  enqueued  :  0
  date      :  2023-05-16T17:31:07.822309
  total time:  824
  req. time :  412
  URL       :  https://chessdb.cn/queryc_en/?8/2B5/1k6/1Q6/8/3K4/4N1R1/qn6_b_-_-_0_1_moves_b6b5_g2g5

Search at depth  2
  score     :  18968
  PV        :  b6b5 g2g5 b5c6
  queryall  :  5
  bf        :  2.24
  inflight  :  0.00
  chessdbq  :  3
  enqueued  :  0
  date      :  2023-05-16T17:31:08.129510
  total time:  1131
  req. time :  377
  URL       :  https://chessdb.cn/queryc_en/?8/2B5/1k6/1Q6/8/3K4/4N1R1/qn6_b_-_-_0_1_moves_b6b5_g2g5_b5c6
```

New behaviour:
```shell
> python cdbsearch.py --epd "8/2B5/1k6/1Q6/8/3K4/4N1R1/qn6 b - - 0 1" --depthLimit 2
Searched epd :  8/2B5/1k6/1Q6/8/3K4/4N1R1/qn6 b - - 0 1
evalDecay:  2
Concurrency  :  16
Starting date:  2023-05-16T17:30:40.117127
Search at depth  1
  score     :  0
  PV        :  b6b5 c7d6
  queryall  :  2
  bf        :  2.00
  inflight  :  0.00
  chessdbq  :  2
  enqueued  :  0
  date      :  2023-05-16T17:30:40.890106
  total time:  772
  req. time :  386
  URL       :  https://chessdb.cn/queryc_en/?8/2B5/1k6/1Q6/8/3K4/4N1R1/qn6_b_-_-_0_1_moves_b6b5_c7d6

Search at depth  2
  score     :  0
  PV        :  b6b5 c7d6 b5c6
  queryall  :  9
  bf        :  3.00
  inflight  :  1.11
  chessdbq  :  7
  enqueued  :  0
  date      :  2023-05-16T17:30:41.414104
  total time:  1296
  req. time :  185
  URL       :  https://chessdb.cn/queryc_en/?8/2B5/1k6/1Q6/8/3K4/4N1R1/qn6_b_-_-_0_1_moves_b6b5_c7d6_b5c6
```