### PR TITLE
fix bug and deal with bad json replies

### DIFF
--- a/cdbsearch.py
+++ b/cdbsearch.py
@@ -178,20 +178,23 @@ class ChessDB:
                 # special case, request to clear the limit
                 url = api + "?action=clearlimit"
                 self.__apicall(url, timeout)
-                lasterror = "asked to clearlimit"
+                lasterror = "Asked to clearlimit"
                 continue
 
             elif content["status"] == "ok":
                 found = True
-                if "moves" in content:
+                try:
                     for m in content["moves"]:
                         s = m["score"]
                         if not self.cursedWins and 15000 <= abs(s) and abs(s) <= 20000:
                             # cursed wins are TB mates that run afoul of 50mr
                             s = 0
                         result[m["uci"]] = s
-                else:
-                    lasterror = "Unexpectedly missing moves"
+                except:
+                    # we do not trust possibly partial move information received
+                    found = False
+                    result = {"depth": 0}
+                    lasterror = "Unexpected or malformed json reply"
                     continue
 
             elif content["status"] == "checkmate" or content["status"] == "stalemate":


### PR DESCRIPTION
In current main if status `"ok"` is received from the queryall API call without `"moves"`, then the position counts as found and an empty move list is returned. I believe this is an error.

This PR fixes the bug and also catches any other malformed json replies.

