### PR TITLE
add rootBoard to accurately compute level in search tree

### DIFF
--- a/cdbsearch.py
+++ b/cdbsearch.py
@@ -279,7 +279,7 @@ class ChessDB:
             if s < worstscore:
                 worstscore = s
 
-        # guarantee sufficient depth of the executorTree list
+        # guarantee sufficient length of the executorTree list
         while len(self.executorTree) < ply + 1:
             self.executorTree.append(
                 concurrent.futures.ThreadPoolExecutor(max_workers=self.concurrency)

--- a/cdbsearch.py
+++ b/cdbsearch.py
@@ -238,8 +238,10 @@ class ChessDB:
         return depth + decay - 1 if score is not None else min(0, depth + decay - 1 - 1)
 
     def search(self, board, depth):
+        # ply stores how many plies we are away from rootBoard
+        ply = len(board.move_stack) - len(self.rootBoard.move_stack)
         if board.is_checkmate():
-            return (-40000 + board.ply(), ["checkmate"])
+            return (-40000 + ply, ["checkmate"])
 
         if (
             board.is_stalemate()
@@ -281,7 +283,6 @@ class ChessDB:
             if s < worstscore:
                 worstscore = s
 
-        ply = len(board.move_stack) - len(self.rootBoard.move_stack)
         # guarantee sufficient depth of the executorTree list
         while len(self.executorTree) < ply + 1:
             self.executorTree.append(

--- a/cdbsearch.py
+++ b/cdbsearch.py
@@ -75,12 +75,9 @@ class ChessDB:
         # our dictionary to cache intermediate results
         self.TT = AtomicTT()
 
-        # At each level in the tree we need a few threads.
-        # Evaluations can happen at any level, so we can saturate the work executor nevertheless
-        # For the root position two threads are probably enough.
-        self.executorTree = [
-            concurrent.futures.ThreadPoolExecutor(max_workers=min(2, self.concurrency))
-        ]
+        # list of ThreadPoolExecutors, one for each level
+        self.executorTree = []
+
         self.executorWork = concurrent.futures.ThreadPoolExecutor(
             max_workers=self.concurrency
         )


### PR DESCRIPTION
Current main computes the value of `ply` to indicate the level in the tree with `board.ply()`. But this number is based on the full move counter of `board`, see [here](https://python-chess.readthedocs.io/en/latest/_modules/chess.html#Board.ply).

An implication is that the `executorTree` list is unnecessarily long, and the special value for the root level rarely takes effect.

This PR correctly computes the level in the search tree by storing the to-be-searched position in `rootBoard`. 

Observations:
* Ignoring the full move counter from the user-provided EPD would have a similar effect but (a) yield `ply==0` only for positions with white to move and (b) not resolve 50mr draw positions correctly, whereas current main does. Moreover, this approach would never have `ply==0` for EPD's that contain `moves` or for non-empty SAN's.
* The PR reduces the (intended) maximal number of threads at level 0 from `max(2, self.concurrency // 4)` to 2 and chooses just 1 thread if `self.concurrency == 1`. Here "intended" means that in the current code this value hardly ever takes effect.

PS: I am not 100% sure what the best possible value for `max_workers` at root is, so feel free to change it to what you prefer.