### PR TITLE
some simplifications and nice total time output

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -59,8 +59,8 @@ inflight   : Number of active/concurrent requests made to cdb on average.
 chessdbq   : Number of positions requested to cdb.
 enqueued   : Number of positions that did not exist in the database but have been added as part of the search.
 date       : ... you guessed it
-total time : Time spent in milliseconds since the start of the search.
-req. time  : Average time needed to get a cdb list of moves for a position (including those that required enqueuing).
+total time : Time spent since the start of the search.
+req. time  : Average time (in milliseconds) needed to get a cdb list of moves for a position (including those that required enqueuing).
 URL        : Link displaying the found PV in chessdb.
 ```
 

--- a/cdbsearch.py
+++ b/cdbsearch.py
@@ -238,7 +238,7 @@ class ChessDB:
     def search(self, board, depth):
         # returns (bestscore, pv) for current position stored in board
 
-        # ply stores how many plies we are away from rootBoard
+        # ply stores the level of the search tree we are in, i.e. how many plies we are away from rootBoard
         ply = len(board.move_stack) - len(self.rootBoard.move_stack)
 
         if board.is_checkmate():

--- a/cdbsearch.py
+++ b/cdbsearch.py
@@ -1,6 +1,5 @@
 import requests
 import time
-import copy
 import chess
 import sys
 import threading
@@ -213,7 +212,7 @@ class ChessDB:
 
     # query all positions along the PV back to the root
     def reprobe_PV(self, board, PV):
-        local_board = copy.deepcopy(board)
+        local_board = board.copy()
         for ucimove in PV:
             try:
                 move = chess.Move.from_uci(ucimove)
@@ -311,7 +310,7 @@ class ChessDB:
             if newdepth >= 0 and not tried_unscored:
                 board.push(move)
                 futures[ucimove] = self.executorTree[ply].submit(
-                    self.search, copy.deepcopy(board), newdepth
+                    self.search, board.copy(), newdepth
                 )
                 board.pop()
                 tried_unscored = True if score is None else tried_unscored


### PR DESCRIPTION
This PR contains various non-functional simplifications. The only functional change is the new output format for the total elapsed time, which is now in [D days,] [H]H:MM:SS.UU. 

I am sorry for raising so many PRs recently. I am carefully studying the code to see if we can improve the handling of moves that are not yet scored on cdb.

Also sorry that this PR appears to contain the changes of https://github.com/vondele/cdbexplore/pull/24, I hope this does not cause any problems on your side.