### PR TITLE
search all scored brothers of a searched unscored move

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -34,18 +34,19 @@ options:
 Sample output:
 
 ```
-Search at depth  15
-  score     :  124
-  PV        :  d7d5 h2h3 h7h5 g4h5 e7e5 c2c3 h8h5 d2d4 b8c6 d4e5 c6e5 c1f4 e5g6 f4h2 f8d6 b1d2 d6h2 h1h2 g8f6 e2e3 d8d6 h2g2 e8f8 g2g3 a7a5 f1e2 h5e5
-  queryall  :  5357
-  bf        :  1.77
-  inflight  :  11.44
-  chessdbq  :  1463
-  enqueued  :  0
-  date      :  2023-05-06T21:37:31.630978
-  total time:  60905
-  req. time :  41
-  URL       :  https://chessdb.cn/queryc_en/?rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR_w_KQkq_-_moves_g2g4_d7d5_h2h3_h7h5_g4h5_e7e5_c2c3_h8h5_d2d4_b8c6_d4e5_c6e5_c1f4_e5g6_f4h2_f8d6_b1d2_d6h2_h1h2_g8f6_e2e3_d8d6_h2g2_e8f8_g2g3_a7a5_f1e2_h5e5
+Search at depth  11
+  score     :  131
+  PV        :  d7d5 e2e3 b8c6 b1c3 e7e5 d2d4 c8e6 d4e5 c6e5 h2h3 h7h5 g1f3
+  queryall  :  23791
+  bf        :  2.50
+  inflight  :  13.01
+  chessdbq  :  9805
+  enqueued  :  75
+  unscored  :  88
+  date      :  2023-05-20T14:15:27.826349
+  total time:  0:05:52.63
+  req. time :  35
+  URL       :  https://chessdb.cn/queryc_en/?rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR_w_KQkq_-_moves_g2g4_d7d5_e2e3_b8c6_b1c3_e7e5_d2d4_c8e6_d4e5_c6e5_h2h3_h7h5_g1f3
 ```
 
 Meaning of the fields:
@@ -57,7 +58,8 @@ queryall   : Number of positions visited in the search tree, with results provid
 bf         : Branching factor q^(1/d) computed from queryall q and depth d.
 inflight   : Number of active/concurrent requests made to cdb on average.
 chessdbq   : Number of positions requested to cdb.
-enqueued   : Number of positions that did not exist in the database but have been added as part of the search.
+enqueued   : Number of positions that did not exist within cdb but have been added as part of the search.
+unscored   : Number of existing unscored moves within cdb that were assigned a score as part of the search.
 date       : ... you guessed it
 total time : Time spent since the start of the search.
 req. time  : Average time (in milliseconds) needed to get a cdb list of moves for a position (including those that required enqueuing).

--- a/Readme.md
+++ b/Readme.md
@@ -14,7 +14,7 @@ Using some concurrency, fairly deep exploration is quickly possible.
 This is a command line program to explore a single position.
 
 ```
-usage: cdbsearch.py [-h] [--epd EPD | --san SAN] [--depthLimit DEPTHLIMIT] [--concurrency CONCURRENCY] [--evalDecay EVALDECAY]
+usage: cdbsearch.py [-h] [--epd EPD | --san SAN] [--depthLimit DEPTHLIMIT] [--concurrency CONCURRENCY] [--evalDecay EVALDECAY] [--cursedWins]
 
 Explore and extend the Chess Cloud Database (https://chessdb.cn/queryc_en/). Builds a search tree for a given position.
 
@@ -71,7 +71,7 @@ URL        : Link displaying the found PV in chessdb.
 This is a command line program to sequentially explore several positions.
 
 ```
-usage: cdbbulksearch.py [-h] [--depthLimit DEPTHLIMIT] [--concurrency CONCURRENCY] [--evalDecay EVALDECAY] [--bulkConcurrency BULKCONCURRENCY] [--forever] filename
+usage: cdbbulksearch.py [-h] [--depthLimit DEPTHLIMIT] [--concurrency CONCURRENCY] [--evalDecay EVALDECAY] [--cursedWins] [--bulkConcurrency BULKCONCURRENCY] [--forever] filename
 
 Sequentially call cdbsearch for EPDs or book exits stored in a file.
 

--- a/Readme.md
+++ b/Readme.md
@@ -34,19 +34,19 @@ options:
 Sample output:
 
 ```
-Search at depth  11
-  score     :  131
-  PV        :  d7d5 e2e3 b8c6 b1c3 e7e5 d2d4 c8e6 d4e5 c6e5 h2h3 h7h5 g1f3
-  queryall  :  23791
-  bf        :  2.50
-  inflight  :  13.01
-  chessdbq  :  9805
-  enqueued  :  75
-  unscored  :  88
-  date      :  2023-05-20T14:15:27.826349
-  total time:  0:05:52.63
-  req. time :  35
-  URL       :  https://chessdb.cn/queryc_en/?rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR_w_KQkq_-_moves_g2g4_d7d5_e2e3_b8c6_b1c3_e7e5_d2d4_c8e6_d4e5_c6e5_h2h3_h7h5_g1f3
+Search at depth  13
+  score     :  126
+  PV        :  d7d5 e2e3 b8c6 d2d4 e7e5 b1c3 c8e6 d4e5 c6e5 h2h3 h7h5 g1f3 e5f3 d1f3 h5g4
+  queryall  :  24745
+  bf        :  2.18
+  inflight  :  12.55
+  chessdbq  :  6733
+  enqueued  :  5
+  unscored  :  2
+  date      :  2023-05-20T19:31:50.668334
+  total time:  0:02:55.59
+  req. time :  26
+  URL       :  https://chessdb.cn/queryc_en/?rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR_w_KQkq_-_moves_g2g4_d7d5_e2e3_b8c6_d2d4_e7e5_b1c3_c8e6_d4e5_c6e5_h2h3_h7h5_g1f3_e5f3_d1f3_h5g4
 ```
 
 Meaning of the fields:

--- a/cdbsearch.py
+++ b/cdbsearch.py
@@ -259,6 +259,8 @@ class ChessDB:
         if scored_db_moves == {}:
             return (0, ["invalid"])
 
+        scoreCount = len(scored_db_moves) - 1  # number of scored moves for board
+
         # also force a query for high depth moves that do not have a full list of scored moves,
         # we use this to add newly scored moves to our TT
         skipTT_db_moves = None
@@ -313,7 +315,10 @@ class ChessDB:
                 newdepth += 1
 
             # schedule qualifying moves for deeper searches, at most 1 unscored move
-            if newdepth >= 0 and not (score is None and tried_unscored):
+            # for sufficiently large depth and suffiently small scoreCount we possibly schedule an unscored move
+            if (newdepth >= 0 and not (score is None and tried_unscored)) or (
+                score is None and not tried_unscored and depth > 15 + scoreCount
+            ):
                 board.push(move)
                 futures[ucimove] = self.executorTree[ply].submit(
                     self.search, board.copy(), newdepth


### PR DESCRIPTION
If I understand the current code correctly, then if an unscored move is selected for deeper search:
* only a randomly selected unscored move is scheduled if there are more than one
* of the scored moves, a random selection will get scheduled as well

This PR makes the code more consistent by:
* scheduling _all_ qualifying unscored moves for deeper search if there are more than one
* scheduling _no_ scored move for deeper search if unscored moves have been scheduled

In addition, we add a counter for such unscored moves that are triggered for search, and update the Readme accordingly.
