### PR TITLE
fix total time display

### DIFF
--- a/cdbsearch.py
+++ b/cdbsearch.py
@@ -424,9 +424,8 @@ def cdbsearch(epd, depthLimit, concurrency, evalDecay, cursedWins=False):
             print("  enqueued  : ", chessdb.count_enqueued.get())
             print("  unscored  : ", chessdb.count_unscored.get())
             print("  date      : ", datetime.now().isoformat())
-            print(
-                "  total time: ", str(timedelta(seconds=int(100 * runtime) / 100))[:-4]
-            )
+            timestr = str(timedelta(seconds=int(100 * runtime) / 100))
+            print("  total time: ", timestr[: -4 if "." in timestr else None])
             print(
                 "  req. time : ",
                 int(1000 * runtime / chessdb.count_uncached.get()),


### PR DESCRIPTION
Unfortunately https://github.com/vondele/cdbexplore/pull/26 introduced a mistake in the total time display when there are no milliseconds. Then `timedelta` returns a string without ".UUUUUU", and so `[:-4]` would remove "M:SS".
