### PR TITLE
Change mate score scheme

### DIFF
--- a/cdbsearch.py
+++ b/cdbsearch.py
@@ -243,7 +243,7 @@ class ChessDB:
         ply = len(board.move_stack) - len(self.rootBoard.move_stack)
 
         if board.is_checkmate():
-            return (-40000 + ply, ["checkmate"])
+            return (-29999, ["checkmate"])
 
         if (
             board.is_stalemate()
@@ -369,6 +369,11 @@ class ChessDB:
 
         if depth > 15:
             self.reprobe_PV(board, minicache[bestmove])
+
+        if bestscore > 25000:
+            bestscore -= 1
+        elif bestscore < -25000:
+            bestscore += 1
 
         return (bestscore, minicache[bestmove])
 


### PR DESCRIPTION
To be more compatible with cdb mate scoring, instead of scoring mates in distance from root, directly at the leaf, adjust mate scores by 1 for each ply. This more compatible search leads to more PVs ending on checkmate explicitly, and for lines for which cdb has the shortest mate already, the score will be constant.

Might need some testing.