### PR TITLE
correct offset to cdb mate evals

### DIFF
--- a/cdbsearch.py
+++ b/cdbsearch.py
@@ -7,6 +7,12 @@ import concurrent.futures
 from datetime import datetime, timedelta
 from multiprocessing import freeze_support
 
+# current conventions on chessdb.cn for mates, TBwins, cursed wins and special evals
+CDB_MATE = 30000
+CDB_TBWIN = 25000
+CDB_CURSED = 20000
+CDB_SPECIAL = 15000
+
 
 class AtomicTT:
     def __init__(self):
@@ -187,9 +193,13 @@ class ChessDB:
                 try:
                     for m in content["moves"]:
                         s = m["score"]
-                        if not self.cursedWins and 15000 <= abs(s) and abs(s) <= 20000:
-                            # cursed wins are TB mates that run afoul of 50mr
-                            s = 0
+                        if abs(s) >= CDB_SPECIAL:
+                            if not self.cursedWins and abs(s) <= CDB_CURSED:
+                                # cursed wins are TB mates that run afoul of 50mr
+                                s = 0
+                            else:
+                                # to stay in sync with cdb evals, we need to counter-act the bestscore off-set applied later on
+                                s += 1 if s >= 0 else -1
                         result[m["uci"]] = s
                 except:
                     # we do not trust possibly partial move information received
@@ -239,11 +249,8 @@ class ChessDB:
     def search(self, board, depth):
         # returns (bestscore, pv) for current position stored in board
 
-        # ply stores the level of the search tree we are in, i.e. how many plies we are away from rootBoard
-        ply = len(board.move_stack) - len(self.rootBoard.move_stack)
-
         if board.is_checkmate():
-            return (-29999, ["checkmate"])
+            return (-CDB_MATE, ["checkmate"])
 
         if (
             board.is_stalemate()
@@ -273,9 +280,9 @@ class ChessDB:
                     )
                     break
 
-        bestscore = -40001
+        bestscore = -(CDB_MATE + 1)
         bestmove = None
-        worstscore = +40001
+        worstscore = CDB_MATE + 1
 
         for m, s in scored_db_moves.items():
             if m == "depth":
@@ -285,6 +292,9 @@ class ChessDB:
                 bestmove = m
             if s < worstscore:
                 worstscore = s
+
+        # ply stores the level of the search tree we are in, i.e. how many plies we are away from rootBoard
+        ply = len(board.move_stack) - len(self.rootBoard.move_stack)
 
         # guarantee sufficient length of the executorTree list
         while len(self.executorTree) < ply + 1:
@@ -357,7 +367,7 @@ class ChessDB:
         self.TT.set(board.epd(), newly_scored_moves)
 
         # find bestmove and associated PV
-        bestscore = -40001
+        bestscore = -(CDB_MATE + 1)
         for m, s in newly_scored_moves.items():
             if m == "depth":
                 continue
@@ -370,10 +380,10 @@ class ChessDB:
         if depth > 15:
             self.reprobe_PV(board, minicache[bestmove])
 
-        if bestscore > 25000:
-            bestscore -= 1
-        elif bestscore < -25000:
-            bestscore += 1
+        # for lines leading to mates, TBwins and cursed wins we do not use mini-max, but rather store the distance in ply
+        # this means local evals for such nodes will always be in sync with cdb
+        if abs(bestscore) > CDB_SPECIAL:
+            bestscore -= 1 if bestscore >= 0 else -1
 
         return (bestscore, minicache[bestmove])
 


### PR DESCRIPTION
After https://github.com/vondele/cdbexplore/pull/32 the output for `python cdbsearch.py --san "1. f3 e5 2. g4" --depthLimit 1` is 

```
Searched epd :  rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - moves f2f3 e7e5 g2g4
evalDecay:  2
Concurrency  :  16
Starting date:  2023-05-24T14:09:31.704329
Search at depth  1
  score     :  29998
  PV        :  d8h4 checkmate
  queryall  :  1
  bf        :  1.00
  inflight  :  0.00
  chessdbq  :  1
  enqueued  :  0
  unscored  :  0
  date      :  2023-05-24T14:09:32.148034
  total time:  0:00:00.44
  req. time :  443
  URL       :  https://chessdb.cn/queryc_en/?rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR_w_KQkq_-_moves_f2f3_e7e5_g2g4_d8h4
  ```
  
giving an eval of 29998 for this mate-in-1 position. This is unfortunate, since (a) it differs by 1 from the cdb eval of 29999, and (b) for the side-to-mate the ply counter is usually odd and not even.

This PR fixes this behaviour, giving the correct eval 29999 for the above position. The PR also maintains eval stability along the mating line until and beyond the checkmate node being reached in the local search. For example: `python cdbsearch.py --epd "1B5b/1p1N4/1Pp5/2P3p1/K1pk3p/2N5/2nP1p2/1b3B2 w - -" --depthLimit 5 --evalDecay 0` gives

```
Searched epd :  1B5b/1p1N4/1Pp5/2P3p1/K1pk3p/2N5/2nP1p2/1b3B2 w - -
evalDecay:  0
Concurrency  :  16
Starting date:  2023-05-24T14:13:15.809280
Search at depth  1
  score     :  29993
  PV        :  d7f8 d4c5
  queryall  :  2
  bf        :  2.00
  inflight  :  0.00
  chessdbq  :  2
  enqueued  :  0
  unscored  :  0
  date      :  2023-05-24T14:13:16.668058
  total time:  0:00:00.85
  req. time :  429
  URL       :  https://chessdb.cn/queryc_en/?1B5b/1p1N4/1Pp5/2P3p1/K1pk3p/2N5/2nP1p2/1b3B2_w_-_-_moves_d7f8_d4c5

Search at depth  2
  score     :  29993
  PV        :  d7f8 d4c5 f8d7
  queryall  :  5
  bf        :  2.24
  inflight  :  0.00
  chessdbq  :  3
  enqueued  :  0
  unscored  :  0
  date      :  2023-05-24T14:13:16.968321
  total time:  0:00:01.15
  req. time :  386
  URL       :  https://chessdb.cn/queryc_en/?1B5b/1p1N4/1Pp5/2P3p1/K1pk3p/2N5/2nP1p2/1b3B2_w_-_-_moves_d7f8_d4c5_f8d7

Search at depth  3
  score     :  29993
  PV        :  d7f8 d4c5 f8d7 c5d4
  queryall  :  9
  bf        :  2.08
  inflight  :  0.00
  chessdbq  :  4
  enqueued  :  0
  unscored  :  0
  date      :  2023-05-24T14:13:17.272658
  total time:  0:00:01.46
  req. time :  365
  URL       :  https://chessdb.cn/queryc_en/?1B5b/1p1N4/1Pp5/2P3p1/K1pk3p/2N5/2nP1p2/1b3B2_w_-_-_moves_d7f8_d4c5_f8d7_c5d4

Search at depth  4
  score     :  29993
  PV        :  d7f8 d4c5 f8d7 c5d4 b8d6
  queryall  :  14
  bf        :  1.93
  inflight  :  0.00
  chessdbq  :  5
  enqueued  :  0
  unscored  :  0
  date      :  2023-05-24T14:13:17.600080
  total time:  0:00:01.79
  req. time :  358
  URL       :  https://chessdb.cn/queryc_en/?1B5b/1p1N4/1Pp5/2P3p1/K1pk3p/2N5/2nP1p2/1b3B2_w_-_-_moves_d7f8_d4c5_f8d7_c5d4_b8d6

Search at depth  5
  score     :  29993
  PV        :  d7f8 d4c5 f8d7 c5d4 b8d6 h8g7 d6c5 checkmate
  queryall  :  32
  bf        :  2.00
  inflight  :  2.06
  chessdbq  :  18
  enqueued  :  0
  unscored  :  0
  date      :  2023-05-24T14:13:18.523791
  total time:  0:00:02.71
  req. time :  150
  URL       :  https://chessdb.cn/queryc_en/?1B5b/1p1N4/1Pp5/2P3p1/K1pk3p/2N5/2nP1p2/1b3B2_w_-_-_moves_d7f8_d4c5_f8d7_c5d4_b8d6_h8g7_d6c5
```

Note that main/master would constantly show `29992` here.

For easy maintainability in future, this PR introduces internal constants for the special values used by cdb for mates, TBwins and cursed wins. 

Finally, the same 1-ply decay that is employed by cdb for these special scores is now also used for the local search tree.