### PR TITLE
option --TBsearch

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -14,7 +14,7 @@ Using some concurrency, fairly deep exploration is quickly possible.
 This is a command line program to explore a single position.
 
 ```
-usage: cdbsearch.py [-h] [--epd EPD | --san SAN] [--depthLimit DEPTHLIMIT] [--concurrency CONCURRENCY] [--evalDecay EVALDECAY] [--cursedWins] [--proveMates] [--user USER]
+usage: cdbsearch.py [-h] [--epd EPD | --san SAN] [--depthLimit DEPTHLIMIT] [--concurrency CONCURRENCY] [--evalDecay EVALDECAY] [--cursedWins] [--TBsearch] [--proveMates] [--user USER]
 
 Explore and extend the Chess Cloud Database (https://chessdb.cn/queryc_en/). Builds a search tree for a given position.
 
@@ -29,6 +29,7 @@ options:
   --evalDecay EVALDECAY
                         Depth decrease per cp eval-to-best. A small number will use a very narrow search, 0 will essentially just follow PV lines. A wide search will likely enqueue many positions. (default: 2)
   --cursedWins          Treat cursed wins as wins. (default: False)
+  --TBsearch            Extend the searching and exploration of lines into cdb's EGTB. (default: False)
   --proveMates          Attempt to prove that mate PV lines have no better defence. Proven mates are indicated with "CHECKMATE" at the end of the PV, whereas unproven ones use "checkmate". (default: False)
   --user USER           Add this username to the http user-agent header. (default: None)
 ``` 
@@ -112,7 +113,7 @@ Search at depth  1
 This is a command line program to sequentially explore several positions.
 
 ```
-usage: cdbbulksearch.py [-h] [--plyBegin PLYBEGIN] [--plyEnd PLYEND] [--shuffle] [--depthLimit DEPTHLIMIT] [--concurrency CONCURRENCY] [--evalDecay EVALDECAY] [--cursedWins] [--proveMates] [--user USER] [--bulkConcurrency BULKCONCURRENCY] [--forever] [--reload] filename
+usage: cdbbulksearch.py [-h] [--plyBegin PLYBEGIN] [--plyEnd PLYEND] [--shuffle] [--depthLimit DEPTHLIMIT] [--concurrency CONCURRENCY] [--evalDecay EVALDECAY] [--cursedWins] [--TBsearch] [--proveMates] [--user USER] [--bulkConcurrency BULKCONCURRENCY] [--forever] [--reload] filename
 
 Invoke cdbsearch for positions loaded from a file.
 
@@ -131,6 +132,7 @@ options:
   --evalDecay EVALDECAY
                         Argument passed to cdbsearch. (default: 2)
   --cursedWins          Argument passed to cdbsearch. (default: False)
+  --TBsearch            Argument passed to cdbsearch. (default: False)
   --proveMates          Argument passed to cdbsearch. (default: False)
   --user USER           Argument passed to cdbsearch. (default: None)
   --bulkConcurrency BULKCONCURRENCY

--- a/cdbbulksearch.py
+++ b/cdbbulksearch.py
@@ -7,7 +7,9 @@ from multiprocessing import freeze_support, active_children
 from collections import deque
 
 
-def wrapcdbsearch(epd, depthLimit, concurrency, evalDecay, cursedWins, proveMates):
+def wrapcdbsearch(
+    epd, depthLimit, concurrency, evalDecay, cursedWins, TBsearch, proveMates
+):
     old_stdout = sys.stdout
     sys.stdout = mystdout = StringIO()
     try:
@@ -18,6 +20,7 @@ def wrapcdbsearch(epd, depthLimit, concurrency, evalDecay, cursedWins, proveMate
                 concurrency=concurrency,
                 evalDecay=evalDecay,
                 cursedWins=cursedWins,
+                TBsearch=TBsearch,
                 proveMates=proveMates,
             )
         )
@@ -170,6 +173,11 @@ if __name__ == "__main__":
         help="Argument passed to cdbsearch.",
     )
     argParser.add_argument(
+        "--TBsearch",
+        action="store_true",
+        help="Argument passed to cdbsearch.",
+    )
+    argParser.add_argument(
         "--proveMates",
         action="store_true",
         help="Argument passed to cdbsearch.",
@@ -260,6 +268,7 @@ if __name__ == "__main__":
                     concurrency=args.concurrency,
                     evalDecay=args.evalDecay,
                     cursedWins=args.cursedWins,
+                    TBsearch=args.TBsearch,
                     proveMates=args.proveMates,
                 )
                 taskCounter.inc()


### PR DESCRIPTION
After discussions with noob on sf-discord, by default we no longer continue searches into 7men TBs.

I believe this needs some testing. In particular, I am not sure that 7men positions with castling rights are dealt with correctly. All moves in such positions are now assigned a value of 1cp from `queryall` (not 0, to differentiate them from true EGTB draws), and we only terminate the search of a line once this has been resolved to draw or win/loss.

Sample output for a TB position with cr for `python cdbsearch.py --epd "r3k3/8/4K3/8/8/8/8/4Q3 w q -"`:
```
Root position:  r3k3/8/4K3/8/8/8/8/4Q3 w q -
evalDecay    :  2
Concurrency  :  16
Starting date:  2023-06-05T19:51:12.920550
Search at depth  1
  cdb PV len:  0
  score     :  -1
  PV        :  e6f6 e8f8
  PV len    :  2
  max ply   :  1
  queryall  :  24
  bf        :  24.00
  inflightR :  9.62
  inflightQ :  11.54
  chessdbq  :  24
  enqueued  :  24
  unscored  :  0
  date      :  2023-06-05T19:51:14.961980
  total time:  0:00:02.04
  cdb time  :  85
  URL       :  https://chessdb.cn/queryc_en/?r3k3/8/4K3/8/8/8/8/4Q3_w_q_-_moves_e6f6_e8f8

Search at depth  2
  cdb PV len:  0
  score     :  24992
  PV        :  e6d6 e8f8 e1f1 EGTB
  PV len    :  3
  max ply   :  1
  queryall  :  295
  bf        :  17.18
  inflightR :  9.52
  inflightQ :  114.04
  chessdbq  :  271
  enqueued  :  24
  unscored  :  0
  date      :  2023-06-05T19:51:21.092712
  total time:  0:00:08.17
  cdb time  :  30
  URL       :  https://chessdb.cn/queryc_en/?r3k3/8/4K3/8/8/8/8/4Q3_w_q_-_moves_e6d6_e8f8_e1f1

Search at depth  3
  cdb PV len:  0
  score     :  24992
  PV        :  e6d6 EGTB
  PV len    :  1
  max ply   :  1
  queryall  :  296
  bf        :  6.66
  inflightR :  9.52
  inflightQ :  114.04
  chessdbq  :  271
  enqueued  :  24
  unscored  :  0
  date      :  2023-06-05T19:51:21.366349
  total time:  0:00:08.44
  cdb time  :  31
  URL       :  https://chessdb.cn/queryc_en/?r3k3/8/4K3/8/8/8/8/4Q3_w_q_-_moves_e6d6
```

Searches for EGTB positions terminate immediately, e.g. `python cdbsearch.py --epd "3qk3/8/8/8/3Pp3/8/8/3QK3 b - d3"` gives
```
Root position:  3qk3/8/8/8/3Pp3/8/8/3QK3 b - d3
evalDecay    :  2
Concurrency  :  16
Starting date:  2023-06-05T19:51:52.210946
Search at depth  1
  cdb PV len:  1
  score     :  0
  PV        :  d8h4 draw
  PV len    :  1
  max ply   :  0
  queryall  :  3
  bf        :  3.00
  inflightR :  0.67
  inflightQ :  2.00
  chessdbq  :  3
  enqueued  :  0
  unscored  :  0
  date      :  2023-06-05T19:51:52.848107
  total time:  0:00:00.63
  cdb time  :  212
  URL       :  https://chessdb.cn/queryc_en/?3qk3/8/8/8/3Pp3/8/8/3QK3_b_-_d3_moves_d8h4
```

An example for an 8men position with best move a capture into 7men is this: `python cdbsearch.py --epd "4k3/ppp2p2/8/8/4p3/8/4Q3/4K3 w - - 0 1" --depthLimit 1`
```
Root position:  4k3/ppp2p2/8/8/4p3/8/4Q3/4K3 w - - 0 1
evalDecay    :  2
Concurrency  :  16
Starting date:  2023-06-05T20:32:25.336233
Search at depth  1
  cdb PV len:  1
  score     :  24996
  PV        :  e2e4 e8f8 e4b7 EGTB
  PV len    :  3
  max ply   :  2
  queryall  :  7
  bf        :  7.00
  inflightR :  0.57
  inflightQ :  2.14
  chessdbq  :  7
  enqueued  :  0
  unscored  :  0
  date      :  2023-06-05T20:32:26.752795
  total time:  0:00:01.41
  cdb time  :  202
  URL       :  https://chessdb.cn/queryc_en/?4k3/ppp2p2/8/8/4p3/8/4Q3/4K3_w_-_-_0_1_moves_e2e4_e8f8_e4b7
```

Here I do not understand why the PV shows 3 moves. Given the code, I would expect `e2e4 e8f8 EGTB`. Maybe you see the reason? (Edit: The bug has since been fixed, the original PR miscounted the pieces.)

PS: All the `max ply` outputs are from before my last commit, where I corrected the `-1` bit.