### PR TITLE
rename ply to level

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -62,7 +62,7 @@ cdb PV len : Current length of the PV for this position in cdb in plies.
 score      : The standard minimax score found, not using the decay that cdb implements.
 PV         : Best line found.
 PV len     : Length of this PV line in plies.
-max ply    : deepest line searched so far
+max ply    : Length of the deepest line searched so far.
 queryall   : Number of positions visited in the search tree, with results provided by cdb or the local cache.
 bf         : Branching factor q^(1/d) computed from queryall q and depth d.
 inflightR  : Number of concurrent http requests made to cdb on average.


### PR DESCRIPTION
The main change is correcting the offset `-1` for the `max ply` calculation. I noticed that this can be `-1` when we get a checkmate position to search, or any 7men position in the new TBsearch branch.

The old `ply` variable really held the `level` of the search tree we were in, with the pv having one more ply than level, because the last searched node will give us also one more (half)move.

Sample output for `python cdbsearch.py --epd "2N2B2/2N1r3/8/3nQ2R/1k6/8/2B5/R3K3 w Q -" --depthLimit 1 --evalDecay 0` is
```
Root position:  2N2B2/2N1r3/8/3nQ2R/1k6/8/2B5/R3K3 w Q -
evalDecay    :  0
Concurrency  :  16
Starting date:  2023-06-06T08:33:05.569892
Search at depth  1
  cdb PV len:  3
  score     :  29997
  PV        :  e1c1 d5c7 e5c5 checkmate
  PV len    :  3
  max ply   :  3
  queryall  :  16
  bf        :  16.00
  inflightR :  4.40
  inflightQ :  6.00
  chessdbq  :  15
  enqueued  :  0
  unscored  :  0
  date      :  2023-06-06T08:33:07.571697
  total time:  0:00:02
  cdb time  :  133
  URL       :  https://chessdb.cn/queryc_en/?2N2B2/2N1r3/8/3nQ2R/1k6/8/2B5/R3K3_w_Q_-_moves_e1c1_d5c7_e5c5
  ```
  
  Note that `max ply` is 3 here, and not 2. 