### PR TITLE
shorten reprobe_PV

### DIFF
--- a/cdbsearch.py
+++ b/cdbsearch.py
@@ -77,6 +77,8 @@ class ChessDB:
         self.count_sumInflightRequests = AtomicInteger()
         self.count_inflightUncached = AtomicInteger()
         self.count_sumInflightUncached = AtomicInteger()
+        self.count_reprobeQueryall = AtomicInteger()
+        self.count_reprobeQueryall2 = AtomicInteger()
 
         # for timing output
         self.count_starttime = time.perf_counter()
@@ -324,12 +326,18 @@ class ChessDB:
         return self.TT.set(epd, result)
 
     async def reprobe_PV(self, board, pv):
-        """query all positions along the PV back to the root"""
-        for ucimove in pv[: -1 if pv[-1] in ["checkmate", "draw"] else None]:
+        """query all positions in the given PV: from leaf to parent of board"""
+        pvlen = len(pv) - 1 if pv[-1] in ["checkmate", "draw"] else len(pv)
+        self.count_reprobeQueryall.inc(len(board.move_stack))
+        self.count_reprobeQueryall2.inc(min(len(board.move_stack), pvlen + 2))
+        for ucimove in pv[:pvlen]:
             board.push(chess.Move.from_uci(ucimove))
-        while board.move_stack:
+        for _ in range(pvlen + 2):
             asyncio.ensure_future(self.queryall(board.epd(), skipTT=True))
-            board.pop()
+            if board.move_stack:
+                board.pop()
+            else:
+                break
 
     def move_depth(self, bestscore, worstscore, score, depth):
         """returns depth - 1 for bestmove and negative values for bad moves, terminating their search; unscored moves are treated worse than worstmove, returning at most 0"""
@@ -535,6 +543,8 @@ async def cdbsearch(
         uncached = chessdb.count_uncached.get()
         if queryall:
             print("  queryall  : ", queryall)
+            print("  reprobe queryall  : ", chessdb.count_reprobeQueryall.get())
+            print("  reprobe queryall2 : ", chessdb.count_reprobeQueryall2.get())
             print(f"  bf        :  { queryall**(1/depth) :.2f}")
             print(
                 f"  inflightR : { chessdb.count_sumInflightRequests.get() / max(uncached, 1) : .2f}"


### PR DESCRIPTION
So I somehow managed to delete the branch the old PR https://github.com/vondele/cdbexplore/pull/51 was based on. :(

So reopening here. These are provisional stats:
```
Search at depth  24
  cdb PV len:  84
  score     :  143
  PV        :  d7d5 f1g2 c8g4 c2c4 c7c6 d1b3 e7e6 b3b7 b8d7 b1c3 g8e7 c4d5 e6d5 d2d4 a8b8 b7a6 h7h6 g1f3 b8b6 a6a7 e7g6 a7a4 f8b4 a2a3 b4d6 h2h4 g4h5 e1f1 e8g8 a1a2 f8e8 b2b4 b6b8 a4c2 b8a8 g2h3 a8a7 h3g2 d8e7 c3d1 e7d8 d1c3 d8e7 c3d1
  PV len    :  44
  max ply   :  121
  queryall  :  2043896
  reprobe queryall  :  28430
  reprobe queryall2 :  20029
  bf        :  1.83
  inflightR :  13.95
  inflightQ :  287.45
  chessdbq  :  447229
  enqueued  :  38090
  unscored  :  19714
  date      :  2023-06-05T00:17:49.244179
  total time:  3:40:29.45
  cdb time  :  29
  URL       :  https://chessdb.cn/queryc_en/?rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR_w_KQkq_-_moves_g2g4_d7d5_f1g2_c8g4_c2c4_c7c6_d1b3_e7e6_b3b7_b8d7_b1c3_g8e7_c4d5_e6d5_d2d4_a8b8_b7a6_h7h6_g1f3_b8b6_a6a7_e7g6_a7a4_f8b4_a2a3_b4d6_h2h4_g4h5_e1f1_e8g8_a1a2_f8e8_b2b4_b6b8_a4c2_b8a8_g2h3_a8a7_h3g2_d8e7_c3d1_e7d8_d1c3_d8e7_c3d1
```

28430 / 447229 = 6.36%, and 28430 / 20029 = 142%.

I think these numbers could justify merging this, in particular because no information is lost for cdb (in the "twig" A->B->C, the reprobing called for A will pick up any information that was relayed to B from C, and then to A from B).

Of course, before merging I would remove the two counters again.