### PR TITLE
fix missing FEN move counters

### DIFF
--- a/cdbbulksearch.py
+++ b/cdbbulksearch.py
@@ -47,7 +47,7 @@ def load_epds(filename, pgnBegin=-1, pgnEnd=None):
                     if line.startswith("#"):  # ignore comments
                         continue
                     epd, _, moves = line.partition("moves")
-                    epd = " ".join(epd.split()[:4])  # cdb ignores move counters anyway
+                    epd = " ".join(epd.split()[:6])  # include potential move counters
                     epdMoves = " moves"
                     for m in moves.split():
                         if (
@@ -66,7 +66,7 @@ def load_epds(filename, pgnBegin=-1, pgnEnd=None):
     epds = {}
     for item in metalist:
         if isPGN:
-            epd = item.board().epd()
+            epd = item.board().fen()  # include potential move counters
             moves = [None] + list(item.mainline_moves())
             plyBegin = (
                 0


### PR DESCRIPTION
This was my oversight when I introduced these. While cdb itself ignores move counters, these are important for cdbsearch itself to discover 50mr draws.