### PR TITLE
do not restrict extensions on PV line

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -37,25 +37,26 @@ options:
 Sample output:
 
 ```
-Search at depth  12
-  cdb PV len:  39
-  score     :  141
-  PV        :  d7d5 e2e3 b8c6 f1e2 e7e5 d2d4 h7h5 g4g5 d8g5 g1f3 g5g6 d4e5 c8g4 h1g1 g6e6 b1d2 g8h6 f3d4 e6e5 d2f3 e5f6 d4c6 f6c6 d1d4 f7f6
-  PV len    :  25
-  level     :  68
-  max level :  84
-  queryall  :  6830
-  bf        :  2.09
-  chessdbq  :  2020 (29.58% of queryall)
-  enqueued  :  47
+Search at depth  8
+  cdb PV len:  70
+  score     :  143
+  PV        :  d7d5 e2e3 b8c6 d2d4 e7e5 b1c3 c8e6 d4e5 c6e5 h2h3 h7h5 g1f3 e5f3 d1f3 h5g4 h3g4 e6g4 f3g2 h8h1 g2h1 g8f6 c1d2 d8d6 c3b5 d6b6 f2f3 a7a6 b5c3 g4f5
+  PV len    :  29
+  level     :  39
+  max level :  47
+  queryall  :  1596
+  bf        :  2.51
+  chessdbq  :  578 (36.22% of queryall)
+  enqueued  :  8
+  requeued  :  0
   unscored  :  0 (0.00% of enqueued)
-  reprobed  :  163 (8.07% of chessdbq)
-  inflightQ :  80.27
-  inflightR :  10.56
-  cdb time  :  120
-  date      :  2023-06-18T18:56:24.547853
-  total time:  0:04:03.78
-  URL       :  https://chessdb.cn/queryc_en/?rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR_w_KQkq_-_moves_g2g4_d7d5_e2e3_b8c6_f1e2_e7e5_d2d4_h7h5_g4g5_d8g5_g1f3_g5g6_d4e5_c8g4_h1g1_g6e6_b1d2_g8h6_f3d4_e6e5_d2f3_e5f6_d4c6_f6c6_d1d4_f7f6
+  reprobed  :  75 (12.98% of chessdbq)
+  inflightQ :  26.69
+  inflightR :  8.21
+  cdb time  :  223
+  date      :  2023-06-21T08:17:28.101875
+  total time:  0:02:09.36
+  URL       :  https://chessdb.cn/queryc_en/?rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR_w_KQkq_-_moves_g2g4_d7d5_e2e3_b8c6_d2d4_e7e5_b1c3_c8e6_d4e5_c6e5_h2h3_h7h5_g1f3_e5f3_d1f3_h5g4_h3g4_e6g4_f3g2_h8h1_g2h1_g8f6_c1d2_d8d6_c3b5_d6b6_f2f3_a7a6_b5c3_g4f5
 ```
 
 Meaning of the fields:


### PR DESCRIPTION
This restores the old cdbsearch behaviour on PV lines: i.e. we do not limit extensions at all.

For problematic draw-shuffle positions that means that once the `depthMaxExtension` restriction is hit, only _one_ move per level is allowed to be searched deeper. This increases the time it finished low depth searches a little, but worth it IMO. (It now takes 10 minutes.)

```
> python cdbsearch.py --epd "B7/p1p5/kb1p4/p3p3/P1N2p2/6p1/7p/K7 w - -" --depthLimit 2
Root position:  B7/p1p5/kb1p4/p3p3/P1N2p2/6p1/7p/K7 w - -
evalDecay    :  2
Concurrency  :  16
Starting date:  2023-06-21T08:36:39.827547
Search at depth  1
  cdb PV len:  29
  score     :  0
  PV        :  a8e4 d6d5 e4d5 b6e3 d5a8 e3b6 a1b1 b6d4 a8g2 d4g1 b1c2 g1d4 g2a8 d4c5 a8c6 c5f8
  PV len    :  16
  level     :  15
  max level :  16
  queryall  :  977
  bf        :  977.00
  chessdbq  :  702 (71.85% of queryall)
  enqueued  :  6
  requeued  :  26
  unscored  :  0 (0.00% of enqueued)
  reprobed  :  0 (0.00% of chessdbq)
  inflightQ :  182.81
  inflightR :  14.37
  cdb time  :  93
  date      :  2023-06-21T08:37:45.631637
  total time:  0:01:05.80
  URL       :  https://chessdb.cn/queryc_en/?B7/p1p5/kb1p4/p3p3/P1N2p2/6p1/7p/K7_w_-_-_moves_a8e4_d6d5_e4d5_b6e3_d5a8_e3b6_a1b1_b6d4_a8g2_d4g1_b1c2_g1d4_g2a8_d4c5_a8c6_c5f8

Search at depth  2
  cdb PV len:  19
  score     :  0
  PV        :  a8e4 d6d5 e4d5 b6c5 d5a8 c5b6 a1b1 b6d4 a8g2 d4f2 g2h1 f2g1 c4e5 c7c6 e5c4 a6b7 b1c2
  PV len    :  17
  level     :  16
  max level :  17
  queryall  :  32616
  bf        :  180.60
  chessdbq  :  5915 (18.14% of queryall)
  enqueued  :  28
  requeued  :  520
  unscored  :  24 (85.71% of enqueued)
  reprobed  :  16 (0.27% of chessdbq)
  inflightQ :  537.74
  inflightR :  14.01
  cdb time  :  103
  date      :  2023-06-21T08:46:53.476273
  total time:  0:10:13.64
  URL       :  https://chessdb.cn/queryc_en/?B7/p1p5/kb1p4/p3p3/P1N2p2/6p1/7p/K7_w_-_-_moves_a8e4_d6d5_e4d5_b6c5_d5a8_c5b6_a1b1_b6d4_a8g2_d4f2_g2h1_f2g1_c4e5_c7c6_e5c4_a6b7_b1c2
```