### PR TITLE
avoid large shuffling subtrees

### DIFF
--- a/cdbsearch.py
+++ b/cdbsearch.py
@@ -355,6 +355,8 @@ class ChessDB:
     def move_depth(self, bestscore, worstscore, score, depth):
         """returns depth - 1 for bestmove and negative values for bad moves, terminating their search; unscored moves are treated worse than worstmove, returning at most 0"""
         delta = score - bestscore if score is not None else worstscore - bestscore
+        if delta == 0 and bestscore == 0:  # avoid growth of shuffle subtrees
+            delta = -1
         decay = delta // self.evalDecay if self.evalDecay != 0 else 10**6 * delta
         return depth + decay - 1 if score is not None else min(0, depth + decay - 2)
 


### PR DESCRIPTION
This PR inhibits the growth of shuffling/drawn subtrees.

The motivation is as follows. As part of the daily `cdbbulksearch` initiated by [grobtrack](https://github.com/robertnurnberg/grobtrack/blob/fad286f0a90af980f062a9c1cacd6bf429b56c57/do_sfwdl.sh#L109) I have stumbled into completely drawn positions that take a very long time to be resolved by `cdbsearch` to depth 4. For example a position that takes 4 hours to be completed:
```
========================================================================
Awaiting results for exploration of EPD "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1 moves b1a3 e7e5 a3c4 b8c6 e2e4 g8f6 d2d3 d7d5 e4d5 f6d5 g1f3 d8e7 c2c3 c8f5 c4e3 d5e3 c1e3 e8c8 d1a4 f5d7 e1c1 a7a6 a4c2 g7g6 g2g3 f7f6 c1b1 e7f7 f1g2 d7g4 c2a4 h7h5 b1a1 c6e7 a4c2 e7f5 e3c1 f5d6 h2h3 g4e6 c3c4 c8b8 c2c3 f8e7 h1e1 e6c8 a2a3 g6g5 f3d2 g5g4 h3g4 h5g4 g2d5 f7f8 d2b3 d6f5 d3d4 h8h2 d4e5 f6e5 b3a5 e7c5 e1e5 h2f2 a1a2 c5b6 c1g5 d8e8 a5b7 c8b7 e5e8 f8e8 c4c5 b7d5 d1d5 e8c6 d5e5 b8b7 g5d2 f5g3 c3g3 f2d2 c5b6 c6c4 g3b3 c4b3 a2b3 c7b6 e5g5 d2d4 g5g6 d4f4 b3c2 a6a5 c2d2 a5a4 d2e3 f4c4 e3d3 b6b5 g6g5 b7b6 g5g6 b6a5 g6g5 c4f4 d3e3 f4f3 e3d4 f3g3 g5g6 g3g1 d4c3 b5b4" (782 / 10041) to depth 4 ... 
Root position:  rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1 moves b1a3 e7e5 a3c4 b8c6 e2e4 g8f6 d2d3 d7d5 e4d5 f6d5 g1f3 d8e7 c2c3 c8f5 c4e3 d5e3 c1e3 e8c8 d1a4 f5d7 e1c1 a7a6 a4c2 g7g6 g2g3 f7f6 c1b1 e7f7 f1g2 d7g4 c2a4 h7h5 b1a1 c6e7 a4c2 e7f5 e3c1 f5d6 h2h3 g4e6 c3c4 c8b8 c2c3 f8e7 h1e1 e6c8 a2a3 g6g5 f3d2 g5g4 h3g4 h5g4 g2d5 f7f8 d2b3 d6f5 d3d4 h8h2 d4e5 f6e5 b3a5 e7c5 e1e5 h2f2 a1a2 c5b6 c1g5 d8e8 a5b7 c8b7 e5e8 f8e8 c4c5 b7d5 d1d5 e8c6 d5e5 b8b7 g5d2 f5g3 c3g3 f2d2 c5b6 c6c4 g3b3 c4b3 a2b3 c7b6 e5g5 d2d4 g5g6 d4f4 b3c2 a6a5 c2d2 a5a4 d2e3 f4c4 e3d3 b6b5 g6g5 b7b6 g5g6 b6a5 g6g5 c4f4 d3e3 f4f3 e3d4 f3g3 g5g6 g3g1 d4c3 b5b4
evalDecay    :  2
Concurrency  :  16
Starting date:  2023-06-27T08:38:35.076420
Search at depth  1
  cdb PV len:  6
  score     :  0
  PV        :  a3b4 a5b5 g6g8 b5a6 g8a8 a6b5 a8g8 b5a6 g8a8 a6b6 a8g8
  PV len    :  11
  level     :  10
  max level :  11
  queryall  :  252
  bf        :  252.00
  chessdbq  :  203 (80.56% of queryall)
  enqueued  :  7
  requeued  :  84
  unscored  :  0 (0.00% of enqueued)
  reprobed  :  0 (0.00% of chessdbq)
  inflightQ :  46.80
  inflightR :  13.05
  cdb time  :  168
  date      :  2023-06-27T08:39:09.185117
  total time:  0:00:34.10
  URL       :  https://chessdb.cn/queryc_en/?rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR_w_KQkq_-_0_1_moves_b1a3_e7e5_a3c4_b8c6_e2e4_g8f6_d2d3_d7d5_e4d5_f6d5_g1f3_d8e7_c2c3_c8f5_c4e3_d5e3_c1e3_e8c8_d1a4_f5d7_e1c1_a7a6_a4c2_g7g6_g2g3_f7f6_c1b1_e7f7_f1g2_d7g4_c2a4_h7h5_b1a1_c6e7_a4c2_e7f5_e3c1_f5d6_h2h3_g4e6_c3c4_c8b8_c2c3_f8e7_h1e1_e6c8_a2a3_g6g5_f3d2_g5g4_h3g4_h5g4_g2d5_f7f8_d2b3_d6f5_d3d4_h8h2_d4e5_f6e5_b3a5_e7c5_e1e5_h2f2_a1a2_c5b6_c1g5_d8e8_a5b7_c8b7_e5e8_f8e8_c4c5_b7d5_d1d5_e8c6_d5e5_b8b7_g5d2_f5g3_c3g3_f2d2_c5b6_c6c4_g3b3_c4b3_a2b3_c7b6_e5g5_d2d4_g5g6_d4f4_b3c2_a6a5_c2d2_a5a4_d2e3_f4c4_e3d3_b6b5_g6g5_b7b6_g5g6_b6a5_g6g5_c4f4_d3e3_f4f3_e3d4_f3g3_g5g6_g3g1_d4c3_b5b4_a3b4_a5b5_g6g8_b5a6_g8a8_a6b5_a8g8_b5a6_g8a8_a6b6_a8g8

Search at depth  2
  cdb PV len:  8
  score     :  0
  PV        :  a3b4 a5b5 g6g8 b5c6 g8g6 c6b5 g6g7 g1c1 c3d3 c1c4 g7b7 b5a6 b7b8
  PV len    :  13
  level     :  12
  max level :  13
  queryall  :  1922
  bf        :  43.84
  chessdbq  :  1239 (64.46% of queryall)
  enqueued  :  18
  requeued  :  602
  unscored  :  4 (22.22% of enqueued)
  reprobed  :  40 (3.23% of chessdbq)
  inflightQ :  263.15
  inflightR :  13.36
  cdb time  :  86
  date      :  2023-06-27T08:40:22.052376
  total time:  0:01:46.97
  URL       :  https://chessdb.cn/queryc_en/?rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR_w_KQkq_-_0_1_moves_b1a3_e7e5_a3c4_b8c6_e2e4_g8f6_d2d3_d7d5_e4d5_f6d5_g1f3_d8e7_c2c3_c8f5_c4e3_d5e3_c1e3_e8c8_d1a4_f5d7_e1c1_a7a6_a4c2_g7g6_g2g3_f7f6_c1b1_e7f7_f1g2_d7g4_c2a4_h7h5_b1a1_c6e7_a4c2_e7f5_e3c1_f5d6_h2h3_g4e6_c3c4_c8b8_c2c3_f8e7_h1e1_e6c8_a2a3_g6g5_f3d2_g5g4_h3g4_h5g4_g2d5_f7f8_d2b3_d6f5_d3d4_h8h2_d4e5_f6e5_b3a5_e7c5_e1e5_h2f2_a1a2_c5b6_c1g5_d8e8_a5b7_c8b7_e5e8_f8e8_c4c5_b7d5_d1d5_e8c6_d5e5_b8b7_g5d2_f5g3_c3g3_f2d2_c5b6_c6c4_g3b3_c4b3_a2b3_c7b6_e5g5_d2d4_g5g6_d4f4_b3c2_a6a5_c2d2_a5a4_d2e3_f4c4_e3d3_b6b5_g6g5_b7b6_g5g6_b6a5_g6g5_c4f4_d3e3_f4f3_e3d4_f3g3_g5g6_g3g1_d4c3_b5b4_a3b4_a5b5_g6g8_b5c6_g8g6_c6b5_g6g7_g1c1_c3d3_c1c4_g7b7_b5a6_b7b8

Search at depth  3
  cdb PV len:  9
  score     :  0
  PV        :  a3b4 a5b5 g6g8 b5c6 g8g6 c6b7 g6g5 b7a6 g5g6 a6b5 g6g8 g1f1 g8g4 f1a1 EGTB
  PV len    :  14
  level     :  13
  max level :  14
  queryall  :  104121
  bf        :  47.04
  chessdbq  :  28024 (26.91% of queryall)
  enqueued  :  130
  requeued  :  17115
  unscored  :  239 (183.85% of enqueued)
  reprobed  :  208 (0.74% of chessdbq)
  inflightQ :  521.58
  inflightR :  13.87
  cdb time  :  61
  date      :  2023-06-27T09:07:27.259279
  total time:  0:28:52.18
  URL       :  https://chessdb.cn/queryc_en/?rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR_w_KQkq_-_0_1_moves_b1a3_e7e5_a3c4_b8c6_e2e4_g8f6_d2d3_d7d5_e4d5_f6d5_g1f3_d8e7_c2c3_c8f5_c4e3_d5e3_c1e3_e8c8_d1a4_f5d7_e1c1_a7a6_a4c2_g7g6_g2g3_f7f6_c1b1_e7f7_f1g2_d7g4_c2a4_h7h5_b1a1_c6e7_a4c2_e7f5_e3c1_f5d6_h2h3_g4e6_c3c4_c8b8_c2c3_f8e7_h1e1_e6c8_a2a3_g6g5_f3d2_g5g4_h3g4_h5g4_g2d5_f7f8_d2b3_d6f5_d3d4_h8h2_d4e5_f6e5_b3a5_e7c5_e1e5_h2f2_a1a2_c5b6_c1g5_d8e8_a5b7_c8b7_e5e8_f8e8_c4c5_b7d5_d1d5_e8c6_d5e5_b8b7_g5d2_f5g3_c3g3_f2d2_c5b6_c6c4_g3b3_c4b3_a2b3_c7b6_e5g5_d2d4_g5g6_d4f4_b3c2_a6a5_c2d2_a5a4_d2e3_f4c4_e3d3_b6b5_g6g5_b7b6_g5g6_b6a5_g6g5_c4f4_d3e3_f4f3_e3d4_f3g3_g5g6_g3g1_d4c3_b5b4_a3b4_a5b5_g6g8_b5c6_g8g6_c6b7_g6g5_b7a6_g5g6_a6b5_g6g8_g1f1_g8g4_f1a1

Search at depth  4
  cdb PV len:  16
  score     :  0
  PV        :  a3b4 a5b5 g6g8 b5c6 g8g7 c6b5 g7g5 b5a6 g5g6 a6b5 g6g7 g1c1 c3d3 b5b4 g7a7 EGTB
  PV len    :  15
  level     :  14
  max level :  15
  queryall  :  2194312
  bf        :  38.49
  chessdbq  :  183596 (8.37% of queryall)
  enqueued  :  1301
  requeued  :  139426
  unscored  :  5097 (391.78% of enqueued)
  reprobed  :  380 (0.21% of chessdbq)
  inflightQ :  286.80
  inflightR :  14.10
  cdb time  :  78
  date      :  2023-06-27T12:38:31.774758
  total time:  3:59:56.69
  URL       :  https://chessdb.cn/queryc_en/?rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR_w_KQkq_-_0_1_moves_b1a3_e7e5_a3c4_b8c6_e2e4_g8f6_d2d3_d7d5_e4d5_f6d5_g1f3_d8e7_c2c3_c8f5_c4e3_d5e3_c1e3_e8c8_d1a4_f5d7_e1c1_a7a6_a4c2_g7g6_g2g3_f7f6_c1b1_e7f7_f1g2_d7g4_c2a4_h7h5_b1a1_c6e7_a4c2_e7f5_e3c1_f5d6_h2h3_g4e6_c3c4_c8b8_c2c3_f8e7_h1e1_e6c8_a2a3_g6g5_f3d2_g5g4_h3g4_h5g4_g2d5_f7f8_d2b3_d6f5_d3d4_h8h2_d4e5_f6e5_b3a5_e7c5_e1e5_h2f2_a1a2_c5b6_c1g5_d8e8_a5b7_c8b7_e5e8_f8e8_c4c5_b7d5_d1d5_e8c6_d5e5_b8b7_g5d2_f5g3_c3g3_f2d2_c5b6_c6c4_g3b3_c4b3_a2b3_c7b6_e5g5_d2d4_g5g6_d4f4_b3c2_a6a5_c2d2_a5a4_d2e3_f4c4_e3d3_b6b5_g6g5_b7b6_g5g6_b6a5_g6g5_c4f4_d3e3_f4f3_e3d4_f3g3_g5g6_g3g1_d4c3_b5b4_a3b4_a5b5_g6g8_b5c6_g8g7_c6b5_g7g5_b5a6_g5g6_a6b5_g6g7_g1c1_c3d3_b5b4_g7a7
```

And at present the same script is stuck for more than 8 hours on this position: 
```
rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1 moves b1a3 e7e5 a3c4 b8c6 e2e4 g8f6 d2d3 d7d5 e4d5 f6d5 g1f3 d8e7 c2c3 c8f5 c4e3 d5e3 c1e3 e8c8 d1a4 f5d7 e1c1 a7a6 a4c2 g7g6 g2g3 f7f6 c1b1 e7f7 f1g2 d7g4 c2a4 h7h5 b1a1 c8b8 h2h3 g4d7 a4c2 d7e6 f3d2 c6e7 d2b3 e7f5 e3c1 f8h6 c1h6 f5h6 h1e1 h6f5 b3c5 e6d5 g2d5 f7d5 c5e4 h8f8 c2b3 d5c6 h3h4 b7b6 a1b1 a6a5 b3c4 c6c4 d3c4 f5d6 e4d6 d8d6 b1c2 b8b7 d1d6 c7d6 f2f4 a5a4 b2b4 b7c6 e1f1 e5e4 c2d2 d6d5 d2e3 d5c4 f1d1 f6f5 a2a3 f8e8 d1d2 e8e7 d2d4 b6b5 e3e2 e7d7 d4d7 c6d7 e2f2 d7d6 f2e1 d6e7 e1f2 e7f6 f2e1
```

Edit: Here the finished search after 8.5 hours:
```
Search at depth  4
  cdb PV len:  29
  score     :  0
  PV        :  a4a5 f5g6 c2d2 g6h7 d2c2 h7g6 c2b2 g6h6 b2b1 h6g6 b1c2 g6g5 c2c1 g5h6 c1d2
  PV len    :  15
  level     :  14
  max level :  15
  queryall  :  4151655
  bf        :  45.14
  chessdbq  :  315875 (7.61% of queryall)
  enqueued  :  175
  requeued  :  312347
  unscored  :  852 (486.86% of enqueued)
  reprobed  :  375 (0.12% of chessdbq)
  inflightQ :  165.86
  inflightR :  14.82
  cdb time  :  96
  date      :  2023-06-27T19:00:47.187897
  total time:  8:25:34.90
  URL       :  https://chessdb.cn/queryc_en/?rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR_w_KQkq_-_0_1_moves_b1a3_e7e5_a3c4_b8c6_e2e4_g8f6_d2d3_d7d5_e4d5_f6d5_g1f3_d8e7_c2c3_c8f5_c4e3_d5e3_c1e3_e8c8_d1a4_f5d7_e1c1_a7a6_a4c2_g7g6_g2g3_f7f6_c1b1_e7f7_f1g2_d7g4_c2a4_h7h5_b1a1_c6e7_a4c2_e7f5_e3c1_f5d6_h2h3_g4e6_c3c4_c8b8_c2c3_f8e7_h1e1_e6c8_a2a3_g6g5_f3d2_g5g4_h3g4_c8g4_g2f3_d6f5_f3g4_h5g4_d2b3_h8h2_d1d2_f7h7_d3d4_f5d4_b3d4_e5d4_d2d4_d8d4_c3d4_h2h1_e1h1_h7h1_a1b1_h1h7_b1a2_h7f5_c1f4_f5e6_a3a4_b8c8_a2b3_f6f5_d4h8_c8d7_h8d4_d7c6_d4h8_e7d6_h8h1_e6e4_h1e4_f5e4_f4e3_d6e5_b3c2_c6d6_b2b3_e5f6_c2d2_f6g7_d2c2_c7c6_c2d2_b7b5_e3b6_g7h6_b6e3_h6e3_f2e3_b5b4_d2c1_d6e5_c1c2_e5f5_a4a5_f5g6_c2d2_g6h7_d2c2_h7g6_c2b2_g6h6_b2b1_h6g6_b1c2_g6g5_c2c1_g5h6_c1d2
```

For the first position, the patch takes 5 seconds compared to 4 hours:
```
> python cdbsearch.py --depthLimit 4 --epd "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1 moves b1a3 e7e5 a3c4 b8c6 e2e4 g8f6 d2d3 d7d5 e4d5 f6d5 g1f3 d8e7 c2c3 c8f5 c4e3 d5e3 c1e3 e8c8 d1a4 f5d7 e1c1 a7a6 a4c2 g7g6 g2g3 f7f6 c1b1 e7f7 f1g2 d7g4 c2a4 h7h5 b1a1 c6e7 a4c2 e7f5 e3c1 f5d6 h2h3 g4e6 c3c4 c8b8 c2c3 f8e7 h1e1 e6c8 a2a3 g6g5 f3d2 g5g4 h3g4 h5g4 g2d5 f7f8 d2b3 d6f5 d3d4 h8h2 d4e5 f6e5 b3a5 e7c5 e1e5 h2f2 a1a2 c5b6 c1g5 d8e8 a5b7 c8b7 e5e8 f8e8 c4c5 b7d5 d1d5 e8c6 d5e5 b8b7 g5d2 f5g3 c3g3 f2d2 c5b6 c6c4 g3b3 c4b3 a2b3 c7b6 e5g5 d2d4 g5g6 d4f4 b3c2 a6a5 c2d2 a5a4 d2e3 f4c4 e3d3 b6b5 g6g5 b7b6 g5g6 b6a5 g6g5 c4f4 d3e3 f4f3 e3d4 f3g3 g5g6 g3g1 d4c3 b5b4"
Root position:  rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1 moves b1a3 e7e5 a3c4 b8c6 e2e4 g8f6 d2d3 d7d5 e4d5 f6d5 g1f3 d8e7 c2c3 c8f5 c4e3 d5e3 c1e3 e8c8 d1a4 f5d7 e1c1 a7a6 a4c2 g7g6 g2g3 f7f6 c1b1 e7f7 f1g2 d7g4 c2a4 h7h5 b1a1 c6e7 a4c2 e7f5 e3c1 f5d6 h2h3 g4e6 c3c4 c8b8 c2c3 f8e7 h1e1 e6c8 a2a3 g6g5 f3d2 g5g4 h3g4 h5g4 g2d5 f7f8 d2b3 d6f5 d3d4 h8h2 d4e5 f6e5 b3a5 e7c5 e1e5 h2f2 a1a2 c5b6 c1g5 d8e8 a5b7 c8b7 e5e8 f8e8 c4c5 b7d5 d1d5 e8c6 d5e5 b8b7 g5d2 f5g3 c3g3 f2d2 c5b6 c6c4 g3b3 c4b3 a2b3 c7b6 e5g5 d2d4 g5g6 d4f4 b3c2 a6a5 c2d2 a5a4 d2e3 f4c4 e3d3 b6b5 g6g5 b7b6 g5g6 b6a5 g6g5 c4f4 d3e3 f4f3 e3d4 f3g3 g5g6 g3g1 d4c3 b5b4
evalDecay    :  2
Concurrency  :  16
Starting date:  2023-06-27T20:23:08.636429
Search at depth  1
  cdb PV len:  11
  score     :  0
  PV        :  a3b4 a5b5
  PV len    :  2
  level     :  1
  max level :  2
  queryall  :  15
  bf        :  15.00
  chessdbq  :  15 (100.00% of queryall)
  enqueued  :  0
  requeued  :  0
  unscored  :  0 (0.00% of enqueued)
  reprobed  :  0 (0.00% of chessdbq)
  inflightQ :  7.87
  inflightR :  6.73
  cdb time  :  77
  date      :  2023-06-27T20:23:09.798558
  total time:  0:00:01.16
  URL       :  https://chessdb.cn/queryc_en/?rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR_w_KQkq_-_0_1_moves_b1a3_e7e5_a3c4_b8c6_e2e4_g8f6_d2d3_d7d5_e4d5_f6d5_g1f3_d8e7_c2c3_c8f5_c4e3_d5e3_c1e3_e8c8_d1a4_f5d7_e1c1_a7a6_a4c2_g7g6_g2g3_f7f6_c1b1_e7f7_f1g2_d7g4_c2a4_h7h5_b1a1_c6e7_a4c2_e7f5_e3c1_f5d6_h2h3_g4e6_c3c4_c8b8_c2c3_f8e7_h1e1_e6c8_a2a3_g6g5_f3d2_g5g4_h3g4_h5g4_g2d5_f7f8_d2b3_d6f5_d3d4_h8h2_d4e5_f6e5_b3a5_e7c5_e1e5_h2f2_a1a2_c5b6_c1g5_d8e8_a5b7_c8b7_e5e8_f8e8_c4c5_b7d5_d1d5_e8c6_d5e5_b8b7_g5d2_f5g3_c3g3_f2d2_c5b6_c6c4_g3b3_c4b3_a2b3_c7b6_e5g5_d2d4_g5g6_d4f4_b3c2_a6a5_c2d2_a5a4_d2e3_f4c4_e3d3_b6b5_g6g5_b7b6_g5g6_b6a5_g6g5_c4f4_d3e3_f4f3_e3d4_f3g3_g5g6_g3g1_d4c3_b5b4_a3b4_a5b5

Search at depth  2
  cdb PV len:  6
  score     :  0
  PV        :  c3c4 g1c1 c4d5
  PV len    :  3
  level     :  2
  max level :  3
  queryall  :  31
  bf        :  5.57
  chessdbq  :  25 (80.65% of queryall)
  enqueued  :  1
  requeued  :  0
  unscored  :  0 (0.00% of enqueued)
  reprobed  :  3 (12.00% of chessdbq)
  inflightQ :  6.24
  inflightR :  4.56
  cdb time  :  83
  date      :  2023-06-27T20:23:10.720952
  total time:  0:00:02.08
  URL       :  https://chessdb.cn/queryc_en/?rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR_w_KQkq_-_0_1_moves_b1a3_e7e5_a3c4_b8c6_e2e4_g8f6_d2d3_d7d5_e4d5_f6d5_g1f3_d8e7_c2c3_c8f5_c4e3_d5e3_c1e3_e8c8_d1a4_f5d7_e1c1_a7a6_a4c2_g7g6_g2g3_f7f6_c1b1_e7f7_f1g2_d7g4_c2a4_h7h5_b1a1_c6e7_a4c2_e7f5_e3c1_f5d6_h2h3_g4e6_c3c4_c8b8_c2c3_f8e7_h1e1_e6c8_a2a3_g6g5_f3d2_g5g4_h3g4_h5g4_g2d5_f7f8_d2b3_d6f5_d3d4_h8h2_d4e5_f6e5_b3a5_e7c5_e1e5_h2f2_a1a2_c5b6_c1g5_d8e8_a5b7_c8b7_e5e8_f8e8_c4c5_b7d5_d1d5_e8c6_d5e5_b8b7_g5d2_f5g3_c3g3_f2d2_c5b6_c6c4_g3b3_c4b3_a2b3_c7b6_e5g5_d2d4_g5g6_d4f4_b3c2_a6a5_c2d2_a5a4_d2e3_f4c4_e3d3_b6b5_g6g5_b7b6_g5g6_b6a5_g6g5_c4f4_d3e3_f4f3_e3d4_f3g3_g5g6_g3g1_d4c3_b5b4_c3c4_g1c1_c4d5

Search at depth  3
  cdb PV len:  7
  score     :  0
  PV        :  c3c4 g1c1 c4d5 a5b5
  PV len    :  4
  level     :  3
  max level :  4
  queryall  :  57
  bf        :  3.85
  chessdbq  :  41 (71.93% of queryall)
  enqueued  :  1
  requeued  :  0
  unscored  :  0 (0.00% of enqueued)
  reprobed  :  9 (21.95% of chessdbq)
  inflightQ :  6.56
  inflightR :  4.41
  cdb time  :  72
  date      :  2023-06-27T20:23:11.612620
  total time:  0:00:02.97
  URL       :  https://chessdb.cn/queryc_en/?rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR_w_KQkq_-_0_1_moves_b1a3_e7e5_a3c4_b8c6_e2e4_g8f6_d2d3_d7d5_e4d5_f6d5_g1f3_d8e7_c2c3_c8f5_c4e3_d5e3_c1e3_e8c8_d1a4_f5d7_e1c1_a7a6_a4c2_g7g6_g2g3_f7f6_c1b1_e7f7_f1g2_d7g4_c2a4_h7h5_b1a1_c6e7_a4c2_e7f5_e3c1_f5d6_h2h3_g4e6_c3c4_c8b8_c2c3_f8e7_h1e1_e6c8_a2a3_g6g5_f3d2_g5g4_h3g4_h5g4_g2d5_f7f8_d2b3_d6f5_d3d4_h8h2_d4e5_f6e5_b3a5_e7c5_e1e5_h2f2_a1a2_c5b6_c1g5_d8e8_a5b7_c8b7_e5e8_f8e8_c4c5_b7d5_d1d5_e8c6_d5e5_b8b7_g5d2_f5g3_c3g3_f2d2_c5b6_c6c4_g3b3_c4b3_a2b3_c7b6_e5g5_d2d4_g5g6_d4f4_b3c2_a6a5_c2d2_a5a4_d2e3_f4c4_e3d3_b6b5_g6g5_b7b6_g5g6_b6a5_g6g5_c4f4_d3e3_f4f3_e3d4_f3g3_g5g6_g3g1_d4c3_b5b4_c3c4_g1c1_c4d5_a5b5

Search at depth  4
  cdb PV len:  5
  score     :  0
  PV        :  c3c4 g1c1 c4d5 a5b5 g6g4
  PV len    :  5
  level     :  4
  max level :  5
  queryall  :  163
  bf        :  3.57
  chessdbq  :  128 (78.53% of queryall)
  enqueued  :  2
  requeued  :  23
  unscored  :  0 (0.00% of enqueued)
  reprobed  :  21 (16.41% of chessdbq)
  inflightQ :  22.01
  inflightR :  10.20
  cdb time  :  42
  date      :  2023-06-27T20:23:14.092190
  total time:  0:00:05.45
  URL       :  https://chessdb.cn/queryc_en/?rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR_w_KQkq_-_0_1_moves_b1a3_e7e5_a3c4_b8c6_e2e4_g8f6_d2d3_d7d5_e4d5_f6d5_g1f3_d8e7_c2c3_c8f5_c4e3_d5e3_c1e3_e8c8_d1a4_f5d7_e1c1_a7a6_a4c2_g7g6_g2g3_f7f6_c1b1_e7f7_f1g2_d7g4_c2a4_h7h5_b1a1_c6e7_a4c2_e7f5_e3c1_f5d6_h2h3_g4e6_c3c4_c8b8_c2c3_f8e7_h1e1_e6c8_a2a3_g6g5_f3d2_g5g4_h3g4_h5g4_g2d5_f7f8_d2b3_d6f5_d3d4_h8h2_d4e5_f6e5_b3a5_e7c5_e1e5_h2f2_a1a2_c5b6_c1g5_d8e8_a5b7_c8b7_e5e8_f8e8_c4c5_b7d5_d1d5_e8c6_d5e5_b8b7_g5d2_f5g3_c3g3_f2d2_c5b6_c6c4_g3b3_c4b3_a2b3_c7b6_e5g5_d2d4_g5g6_d4f4_b3c2_a6a5_c2d2_a5a4_d2e3_f4c4_e3d3_b6b5_g6g5_b7b6_g5g6_b6a5_g6g5_c4f4_d3e3_f4f3_e3d4_f3g3_g5g6_g3g1_d4c3_b5b4_c3c4_g1c1_c4d5_a5b5_g6g4
```