### PR TITLE
remove clearlimit API call

### DIFF
--- a/cdbsearch.py
+++ b/cdbsearch.py
@@ -303,9 +303,7 @@ class ChessDB:
                 continue
 
             elif content["status"] == "rate limit exceeded":
-                # special case, request to clear the limit
-                await self.__cdbapicall("?action=clearlimit", timeout)
-                lasterror = "Asked to clearlimit"
+                lasterror = "Rate limit exceeded"
                 continue
 
             elif content["status"] == "ok":


### PR DESCRIPTION
cdb no longer allows to ask for `clearlimit`. This PR tries to take that new behaviour into account: sleeping at least 1 minute when rate limit is exceeded, and increasing the longest sleep time from 1 minute to 10 minutes, to allow the accumulated query backlog to be cleared.