### PR TITLE
add option --maxDepthLimit

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -119,7 +119,7 @@ Search at depth  1
 This is a command line program to sequentially explore several positions.
 
 ```
-usage: cdbbulksearch.py [-h] [--plyBegin PLYBEGIN] [--plyEnd PLYEND] [--shuffle] [--depthLimit DEPTHLIMIT] [--concurrency CONCURRENCY] [--evalDecay EVALDECAY] [--cursedWins] [--TBsearch] [--proveMates] [--user USER] [--bulkConcurrency BULKCONCURRENCY] [--forever] [--reload] filename
+usage: cdbbulksearch.py [-h] [--plyBegin PLYBEGIN] [--plyEnd PLYEND] [--shuffle] [--depthLimit DEPTHLIMIT] [--concurrency CONCURRENCY] [--evalDecay EVALDECAY] [--cursedWins] [--TBsearch] [--proveMates] [--user USER] [--bulkConcurrency BULKCONCURRENCY] [--forever] [--maxDepthLimit MAXDEPTHLIMIT] [--reload] filename
 
 Invoke cdbsearch for positions loaded from a file.
 
@@ -144,6 +144,8 @@ options:
   --bulkConcurrency BULKCONCURRENCY
                         Number of concurrent processes running cdbsearch. (default: 4)
   --forever             Pass positions from filename to cdbsearch in an infinite loop, increasing depthLimit by one after each completed cycle. (default: False)
+  --maxDepthLimit MAXDEPTHLIMIT
+                        Upper bound for dynamically increasing depthLimit. (default: None)
   --reload              Reload positions from filename when tasks for new cycle are needed. (default: False)
 ```
 

--- a/cdbbulksearch.py
+++ b/cdbbulksearch.py
@@ -198,6 +198,12 @@ if __name__ == "__main__":
         help="Pass positions from filename to cdbsearch in an infinite loop, increasing depthLimit by one after each completed cycle.",
     )
     argParser.add_argument(
+        "--maxDepthLimit",
+        help="Upper bound for dynamically increasing depthLimit.",
+        type=int,
+        default=None,
+    )
+    argParser.add_argument(
         "--reload",
         action="store_true",
         help="Reload positions from filename when tasks for new cycle are needed.",
@@ -254,6 +260,8 @@ if __name__ == "__main__":
                     first = False
                 else:
                     depthLimit += 1
+                    if args.maxDepthLimit is not None:
+                        depthLimit = min(depthLimit, args.maxDepthLimit)
                 epdIdx = 0
             elif task is None and len(tasks) == 0:
                 break


### PR DESCRIPTION
Use case is some remote box, where overloading it would mean it can no longer be reached via ssh from the outside. The new option allows `cdbbulksearch` to run forever, without bringing the box to its knees.