### PR TITLE
ignore epd opcodes

### DIFF
--- a/cdbbulksearch.py
+++ b/cdbbulksearch.py
@@ -54,6 +54,7 @@ def load_epds(filename, plyBegin=-1, plyEnd=None):
                 if line:
                     if line.startswith("#"):  # ignore comments
                         continue
+                    line = line.split(";")[0]  # ignore epd opcodes
                     epd, _, moves = line.partition("moves")
                     epd = epd.split()[:6]  # include potential move counters
                     if len(epd) == 6 and not (


### PR DESCRIPTION
This allows `cdbbulksearch` to correctly parse lines where there is no space between the FEN and a `;` preceding additional info.

Example use case: https://github.com/robertnurnberg/caissatrack/blob/main/caissa_daily100.epd