### PR TITLE
always enforce --maxDepthLimit

### DIFF
--- a/cdbbulksearch.py
+++ b/cdbbulksearch.py
@@ -261,8 +261,8 @@ if __name__ == "__main__":
                     first = False
                 else:
                     depthLimit += 1
-                    if args.maxDepthLimit is not None:
-                        depthLimit = min(depthLimit, args.maxDepthLimit)
+                if args.maxDepthLimit is not None:
+                    depthLimit = min(depthLimit, args.maxDepthLimit)
                 epdIdx = 0
             elif task is None and len(tasks) == 0:
                 break


### PR DESCRIPTION
Running main with `python cdbbulksearch.py --forever --maxDepthLimit 2` will still run the first loop with `depthLimit = 5`. This PR fixes this, possibly overriding a given `--depthLimit` with the lower `--maxDepthLimit`.