### PR TITLE
check for illegal moves in extended EPDs

### DIFF
--- a/cdbsearch.py
+++ b/cdbsearch.py
@@ -586,8 +586,17 @@ async def cdbsearch(
         epdMoves = []
     epd = epd.strip()  # avoid leading and trailing spaces in URL below
     board = chess.Board(epd)
-    for ucimove in epdMoves:
-        board.push(chess.Move.from_uci(ucimove))
+    pushedMoves = []
+    for move in epdMoves:
+        uci = chess.Move.from_uci(move)
+        if not uci in board.legal_moves:
+            print(
+                f' - Warning: Encountered illegal move {move} at position "{board.epd()}". Ignoring this and all following moves.'
+            )
+            break
+        board.push(uci)
+        pushedMoves.append(move)
+    epdMoves = pushedMoves
 
     # create a ChessDB
     chessdb = ChessDB(


### PR DESCRIPTION
TIL that `board.push()` does not check for legality. So this PR introduces a check for the user-provided list of moves. All other instances come from cdb, and can thus be trusted.

Main:
```
> python cdbsearch.py --epd "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - moves g2g4 a7a3" --depthLimit 1
Root position:  rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - moves g2g4 a7a3
evalDecay    :  2
Concurrency  :  16
Starting date:  2024-06-11T17:26:40.027073
Search at depth  1
  cdb PV len:  3
  score     :  -81
  PV        :  g1f3
  PV len    :  1
  level     :  4
  max level :  5
  queryall  :  12
  bf        :  12.00
  chessdbq  :  12 (100.00% of queryall)
  enqueued  :  1
  requeued  :  3
  unscored  :  0 (0.00% of enqueued)
  reprobed  :  0 (0.00% of chessdbq)
  inflightQ :  3.33
  inflightR :  2.50
  cdb time  :  4764
  date      :  2024-06-11T17:27:37.205240
  total time:  0:00:57.17
  URL       :  https://chessdb.cn/queryc_en/?rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR_w_KQkq_-_moves_g2g4_a7a3_g1f3
```

Patch:
```
> python cdbsearch.py --epd "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - moves g2g4 a7a3" --depthLimit 1
Root position:  rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - moves g2g4 a7a3
evalDecay    :  2
Concurrency  :  16
Starting date:  2024-06-11T17:31:05.618580
 - Warning: Encountered illegal move a7a3 at position "rnbqkbnr/pppppppp/8/8/6P1/8/PPPPPP1P/RNBQKBNR b KQkq -". Ignoring this and all following moves.
Search at depth  1
  cdb PV len:  72
  score     :  141
  PV        :  d7d5 h2h3
  PV len    :  2
  level     :  73
  max level :  74
  queryall  :  152
  bf        :  152.00
  chessdbq  :  84 (55.26% of queryall)
  enqueued  :  3
  requeued  :  3
  unscored  :  0 (0.00% of enqueued)
  reprobed  :  0 (0.00% of chessdbq)
  inflightQ :  33.57
  inflightR :  12.76
  cdb time  :  745
  date      :  2024-06-11T17:32:08.281168
  total time:  0:01:02.66
  URL       :  https://chessdb.cn/queryc_en/?rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR_w_KQkq_-_moves_g2g4_d7d5_h2h3
```

TL;DR: The pawn move `a7a3` in reply to `g2g4` from the standard start position is illegal. Yet main feeds that position to cdb to be explored, posting also a broken link.