### PR TITLE
ensure a PV is returned for known positions

### DIFF
--- a/cdbsearch.py
+++ b/cdbsearch.py
@@ -149,8 +149,16 @@ class ChessDB:
 
     async def add_cdb_pv_positions(self, epd):
         """query cdb for the PV of the position and create a dictionary containing these positions and their distance to the PV leaf for extensions during search"""
-        content = await self.__cdbapicall(f"?action=querypv&board={epd}&json=1")
-        if content and content.get("status") == "ok" and "pv" in content:
+        content, first = {}, True
+        while not (content and "status" in content):
+            content = await self.__cdbapicall(
+                f"?action=querypv&board={epd}&stable=1&json=1"
+            )
+            if first:
+                first = False
+            else:
+                await asyncio.sleep(5)
+        if content["status"] == "ok" and "pv" in content:
             pv = content["pv"]
             self.cdbPvToLeaf[epd] = len(pv)
             asyncio.ensure_future(self.queryall(epd))


### PR DESCRIPTION
The PR will avoid outputs like the below from main.
```
$ python cdbsearch.py --epd "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - moves g2g4 d7d5 e2e3 e7e5" --concurrency 32
Root position:  rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - moves g2g4 d7d5 e2e3 e7e5
evalDecay    :  2
Concurrency  :  32
Starting date:  2024-07-21T09:56:26.903714
Search at depth  1
  cdb PV len:  0
  score     :  -148
  PV        :  d2d4 h7h5
  PV len    :  2
```

While at it, also switch to stable PVs.