### PR TITLE
introduce --excludeFile option

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -122,7 +122,7 @@ Search at depth  1
 This is a command line program to sequentially explore several positions.
 
 ```
-usage: cdbbulksearch.py [-h] [--plyBegin PLYBEGIN] [--plyEnd PLYEND] [--shuffle] [--depthLimit DEPTHLIMIT] [--timeLimit TIMELIMIT] [--concurrency CONCURRENCY] [--evalDecay EVALDECAY] [--cursedWins] [--TBsearch] [--proveMates] [--user USER] [--suppressErrors] [--bulkConcurrency BULKCONCURRENCY] [--forever] [--maxDepthLimit MAXDEPTHLIMIT] [--reload] filename
+usage: cdbbulksearch.py [-h] [--excludeFile EXCLUDEFILE] [--plyBegin PLYBEGIN] [--plyEnd PLYEND] [--shuffle] [--depthLimit DEPTHLIMIT] [--timeLimit TIMELIMIT] [--concurrency CONCURRENCY] [--evalDecay EVALDECAY] [--cursedWins] [--TBsearch] [--proveMates] [--user USER] [--suppressErrors] [--bulkConcurrency BULKCONCURRENCY] [--forever] [--maxDepthLimit MAXDEPTHLIMIT] [--reload] filename
 
 Invoke cdbsearch for positions loaded from a file.
 
@@ -131,6 +131,8 @@ positional arguments:
 
 options:
   -h, --help            show this help message and exit
+  --excludeFile EXCLUDEFILE
+                        A file with FENs/EPDs that should not be loaded from filename. (default: None)
   --plyBegin PLYBEGIN   Ply in each line of filename from which positions will be searched by cdbsearch. A value of 0 corresponds to the starting FEN without any moves played. Negative values count from the back, as per the Python standard. (default: -1)
   --plyEnd PLYEND       Ply in each line of filename until which positions will be searched by cdbsearch. A value of None means including the final move of the line. (default: None)
   --shuffle             Shuffle the positions to be searched randomly. (default: False)


### PR DESCRIPTION
Rumour has it, this is something that some users want.


```
> tail -n 99999 caissa_sorted_100000.epd > exclude.epd
> python cdbbulksearch.py caissa_sorted_100000.epd --excludeFile exclude.epd
Positions to be explored with concurrency 4.
Loaded 100000 (extended) EPDs from file caissa_sorted_100000.epd.
Kept 1 (extended) EPDs after excluding EPDs from file exclude.epd.
Prepared 1 unique EPDs for exploration.
========================================================================
Awaiting results for exploration of EPD "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq -" (1 / 1) to depth 5 ...
```